### PR TITLE
Fix script abort when line mismatch

### DIFF
--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -169,9 +169,9 @@ check_packages() {
                 local malicious_version="${package_info#*:}"
 
                 # Check both dependencies and devDependencies sections
-                if grep -q "\"$package_name\"" "$package_file" 2>/dev/null; then
+                if grep -q "\"$package_name\":" "$package_file" 2>/dev/null; then
                     local found_version
-                    found_version=$(grep -A1 "\"$package_name\"" "$package_file" | grep -o '"[0-9]\+\.[0-9]\+\.[0-9]\+"' | tr -d '"' | head -1)
+                    found_version=$(grep -A1 "\"$package_name\":" "$package_file" | grep -o '"[0-9]\+\.[0-9]\+\.[0-9]\+"' | tr -d '"' | head -1 || true)
                     if [[ "$found_version" == "$malicious_version" ]]; then
                         COMPROMISED_FOUND+=("$package_file:$package_name@$malicious_version")
                     fi

--- a/test-cases/debug-js/package.json
+++ b/test-cases/debug-js/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "debug",
+  "version": "4.4.3",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/debug-js/debug.git"
+  },
+  "description": "Lightweight debugging utility for Node.js and the browser",
+  "keywords": [
+    "debug",
+    "log",
+    "debugger"
+  ],
+  "files": [
+    "src",
+    "LICENSE",
+    "README.md"
+  ],
+  "author": "Josh Junon (https://github.com/qix-)",
+  "contributors": [
+    "TJ Holowaychuk <tj@vision-media.ca>",
+    "Nathan Rajlich <nathan@tootallnate.net> (http://n8.io)",
+    "Andrew Rhyne <rhyneandrew@gmail.com>"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "lint": "xo",
+    "test": "npm run test:node && npm run test:browser && npm run lint",
+    "test:node": "mocha test.js test.node.js",
+    "test:browser": "karma start --single-run",
+    "test:coverage": "cat ./coverage/lcov.info | coveralls"
+  },
+  "dependencies": {
+    "ms": "^2.1.3"
+  },
+  "devDependencies": {
+    "brfs": "^2.0.1",
+    "browserify": "^16.2.3",
+    "coveralls": "^3.0.2",
+    "karma": "^3.1.4",
+    "karma-browserify": "^6.0.0",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-mocha": "^1.3.0",
+    "mocha": "^5.2.0",
+    "mocha-lcov-reporter": "^1.2.0",
+    "sinon": "^14.0.0",
+    "xo": "^0.23.0"
+  },
+  "peerDependenciesMeta": {
+    "supports-color": {
+      "optional": true
+    }
+  },
+  "main": "./src/index.js",
+  "browser": "./src/browser.js",
+  "engines": {
+    "node": ">=6.0"
+  },
+  "xo": {
+    "rules": {
+      "import/extensions": "off"
+    }
+  }
+}


### PR DESCRIPTION
Thanks a lot for this handy tool, @MonkeyIsNull !

When running the tool agains a real world project I encountered a crash / script abort. Debugging the script brought me to the conclusion that the grep used to filter dependencies is too broad. Additionally the script crashes when the grep command extracting the version number has no match.

I've provided a test case based on https://github.com/debug-js/debug/blob/master/package.json to verify my fix works.

I'm not a bash programmer. I did my best to not mess with the codestyle. If you know a better way to achieve the same results or if I broke your code style please let me know and I'll fix it. Or feel free to modify the patch yourself.

