### PR TITLE
Fix reporting in some bash implementations

### DIFF
--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -854,8 +854,7 @@ generate_report() {
         print_status "$RED" "🚨 HIGH RISK: Malicious workflow files detected:"
         for file in "${WORKFLOW_FILES[@]}"; do
             echo "   - $file"
-            show_file_preview "$file" "Known malicious workflow filename"
-            ((high_risk++))
+            show_file_preview "$file" "HIGH RISK: Known malicious workflow filename"
             high_risk=$((high_risk+1))
         done
     fi
@@ -868,8 +867,7 @@ generate_report() {
             local hash="${entry#*:}"
             echo "   - $file_path"
             echo "     Hash: $hash"
-            show_file_preview "$file_path" "File matches known malicious SHA-256 hash"
-            ((high_risk++))
+            show_file_preview "$file_path" "HIGH RISK: File matches known malicious SHA-256 hash"
             high_risk=$((high_risk+1))
         done
     fi
@@ -882,8 +880,7 @@ generate_report() {
             local package_info="${entry#*:}"
             echo "   - Package: $package_info"
             echo "     Found in: $file_path"
-            show_file_preview "$file_path" "Contains compromised package version: $package_info"
-            ((high_risk++))
+            show_file_preview "$file_path" "HIGH RISK: Contains compromised package version: $package_info"
             high_risk=$((high_risk+1))
         done
         echo -e "   ${YELLOW}NOTE: These specific package versions are known to be compromised.${NC}"
@@ -975,8 +972,7 @@ generate_report() {
             local hook_info="${entry#*:}"
             echo "   - Hook: $hook_info"
             echo "     Found in: $file_path"
-            show_file_preview "$file_path" "Contains suspicious postinstall hook: $hook_info"
-            ((high_risk++))
+            show_file_preview "$file_path" "HIGH RISK: Contains suspicious postinstall hook: $hook_info"
             high_risk=$((high_risk+1))
         done
         echo -e "   ${YELLOW}NOTE: Postinstall hooks can execute arbitrary code during package installation.${NC}"


### PR DESCRIPTION
The reporting was not complete due to the increment syntax not supported by the bash version installed on my system

`GNU bash, Version 5.1.16(1)-release (x86_64-pc-linux-gnu)`

I've switched the increments to another syntax that is - according to the internet - more widely accepted.

Some HIGH RISK findings didn't contain the "HIGH RISK" prefix thus no "context" was printed to console. I've fixed this assuming that this is the behaviour you've intended.