### PR TITLE
Add progress information to detection of malicious content + packages

### DIFF
--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -172,7 +172,7 @@ check_file_hashes() {
             done
         fi
         filesChecked=$((filesChecked+1))
-        echo -ne "$filesChecked / $filesCount checked ($((filesChecked*100/filesCount)) %)\r"
+        echo -ne "\r\033[K$filesChecked / $filesCount checked ($((filesChecked*100/filesCount)) %)"
 
     done < <(find "$scan_dir" -type f \( -name "*.js" -o -name "*.ts" -o -name "*.json" \) -print0 2>/dev/null)
 }
@@ -280,7 +280,7 @@ check_packages() {
         fi
 
         filesChecked=$((filesChecked+1))
-        echo -ne "$filesChecked / $filesCount checked ($((filesChecked*100/filesCount)) %)\r"
+        echo -ne "\r\033[K$filesChecked / $filesCount checked ($((filesChecked*100/filesCount)) %)"
 
     done < <(find "$scan_dir" -name "package.json" -print0 2>/dev/null)
 }


### PR DESCRIPTION
Adds a count for the files found to the status messages and provides a progress indicator during checks.

When scanning our projects the scan was slow and I found myself wondering if the script hangs or if it just takes so long. We've a project with 150.834 files that need to be checked for malicious content and 14.415 `package.json` files.