### PR TITLE
Fix for gnu.coreutils 9.4 on f2fs

### DIFF
--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -611,7 +611,7 @@ check_package_integrity() {
             # Check for recently modified lockfiles with @ctrl packages (potential worm activity)
             if grep -q "@ctrl" "$lockfile" 2>/dev/null; then
                 local file_age
-                file_age=$(stat -f "%m" "$lockfile" 2>/dev/null || echo "0")
+                file_age=$(date -r "$lockfile" +%s 2>/dev/null || echo "0")
                 local current_time
                 current_time=$(date +%s)
                 local age_diff=$((current_time - file_age))


### PR DESCRIPTION
When running on a machine using [f2fs](https://www.kernel.org/doc/html/latest/filesystems/f2fs.html) as it's filesystem, `stat -f '%m' <file>` from gnu.coreutils v9.4 fails with the following error:

```
stat: cannot read file system information for '%m': No such file or directory
```

To remedy this, the modification timestamp of a file can be read using the `date -r <file> +%s` command, which is already relied upon elsewhere in the program.