### PR TITLE
Fix Windows CRLF handling in compromised packages loading

### DIFF
--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -45,6 +45,8 @@ load_compromised_packages() {
     if [[ -f "$packages_file" ]]; then
         # Read packages from file, skipping comments and empty lines
         while IFS= read -r line; do
+            # Trim potential Windows carriage returns
+            line="${line%$'\r'}"
             # Skip comments and empty lines
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
             [[ -z "${line// }" ]] && continue


### PR DESCRIPTION
- Add line trimming to remove carriage returns from package list entries
- Ensures consistent version matching across LF and CRLF line endings
- Fixes undercounting of HIGH RISK findings on Windows systems