### PR TITLE
more cleanup of destructive/non-destructive patterns for Issue #74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Missing Ethereum Wallet Detection**: Restored Ethereum wallet address pattern detection (`0x[a-fA-F0-9]{40}`) that was lost during refactoring
 - **Missing LOW RISK for Framework XMLHttpRequest**: Fixed detection to properly report LOW RISK for legitimate XMLHttpRequest modifications in React Native and Next.js framework code
 - **Duplicate Lockfile Warnings**: Fixed AWK parser that was outputting duplicate findings for packages appearing in both node_modules and dependencies sections
-- **Reduced False Positives for Destructive Patterns**: Standalone `rimraf`, `fs.unlinkSync`, and `fs.rmSync` no longer flagged as CRITICAL. Now only flags deletion commands that target user directories (`$HOME`, `~`, `/home/`) or are combined with credential/auth failure patterns. (GitHub issue #74)
+- **Reduced False Positives for Destructive Patterns**: Standalone `rimraf`, `fs.unlinkSync`, and `fs.rmSync` no longer flagged as CRITICAL. Now only flags deletion commands that target user directories (`$HOME`, `~`, `/home/`) or are combined with credential/auth failure patterns. Fixed regex escaping for literal asterisk matching and excluded `~/path` patterns (Vue.js import aliases). Tightened `exec.*rm` pattern span to prevent false matches on minified code. (GitHub issue #74)
 
 ### Performance
 - **Associative Array Lookups**: O(1) package lookups instead of O(n) linear searches


### PR DESCRIPTION
 Summary of fixes for Issue #74:

  1. Removed overly broad patterns from basic_destructive_regex:
    - Removed standalone rimraf, fs.unlinkSync, fs.rmSync
    - Now only flags when deletion targets user directories ($HOME, ~, /home/)
  2. Fixed regex escaping for literal asterisk:
    - Changed \\\* to [*] to properly match literal * character
    - Fixed ~[^a-zA-Z] to ~[^a-zA-Z0-9_/] to exclude ~/path (Vue.js import alias)
  3. Tightened exec.*rm pattern in conditional regex:
    - Changed exec.*rm to exec.{1,30}rm to limit span
    - Prevents false matches on minified code where "exec" and "rm" are far apart