### PR TITLE
fix: silent exit on extracting dependencies

### DIFF
--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -1172,19 +1172,19 @@ check_packages() {
     # Use awk to parse JSON dependencies - portable and fast
     # Use null-delimited input to handle filenames with spaces (issue #92)
     tr '\n' '\0' < "$TEMP_DIR/package_files.txt" | \
-        xargs -0 -P "$PARALLELISM" -I {} awk -v file="{}" '
-        /"dependencies":|"devDependencies":/ {flag=1; next}
-        /^[[:space:]]*\}/ {flag=0}
-        flag && /^[[:space:]]*"[^"]+":/ {
-            # Extract "package": "version"
-            gsub(/^[[:space:]]*"/, "")
-            gsub(/":[[:space:]]*"/, ":")
-            gsub(/".*$/, "")
-            if (length($0) > 0 && index($0, ":") > 0) {
-                print file "|" $0
+        xargs -0 -P "$PARALLELISM" -n1 -r awk '
+            /"dependencies":|"devDependencies":/ {flag=1; next}
+            /^[[:space:]]*\}/ {flag=0}
+            flag && /^[[:space:]]*"[^"]+":/ {
+                # Extract "package": "version"
+                gsub(/^[[:space:]]*"/, "")
+                gsub(/":[[:space:]]*"/, ":")
+                gsub(/".*$/, "")
+                if (length($0) > 0 && index($0, ":") > 0) {
+                    print FILENAME "|" $0
+                }
             }
-        }
-    ' {} > "$TEMP_DIR/all_deps.txt" 2>/dev/null
+        ' > "$TEMP_DIR/all_deps.txt" 2>/dev/null
 
     # FAST SET INTERSECTION: Use awk hash lookup instead of grep per line
     print_status "$BLUE" "   Checking dependencies against compromised list..."


### PR DESCRIPTION
I had an issue scanning my monorepo and the script kept exiting without an error.
I had applied a local fix in my fork, but after merging the latest changes which fix the whitespace issue my original issue returned.

This PR fixes #103 

---

Changes from the original version:

- **Remove fragile `xargs` placeholder usage**
  - Original used: `awk -v file="{}" ' ... ' {}` with `xargs` injecting `{}` in multiple places.
  - This tight coupling between `xargs` placeholders and `awk` arguments made the command hard to read and easy to break when refactoring.

- **Let `xargs` pass each file as a normal argument to `awk`**
  - New version calls: `xargs -0 -P "$PARALLELISM" -n1 -r awk ' ... '`
  - `xargs` still runs one `awk` process per file (because of `-n1`), but no longer needs `{}` placeholders in the `awk` invocation.

- **Use awk’s built\-in `FILENAME` instead of a manual `file` variable**
  - Original: `-v file="{}"` and `print file "|" $0`.
  - Fixed: `print FILENAME "|" $0`.
  - `FILENAME` is automatically set by `awk` to the path of the current input file, so there is no need to pass it in via `-v` or keep `{}` in sync.

- **Keep the safe, parallel file handling intact**
  - Still uses `tr '\n' '\0' | xargs -0 -P "$PARALLELISM" -n1 -r`:
    - Handles paths with spaces and special characters via null\-delimited input.
    - Preserves parallelism while simplifying the command line.

Result: same output format (`<package.json path>|<dependency>:<version>`), but with a shorter, clearer, and less error\-prone pipeline.