### PR TITLE
Add 2 missing compromised packages from Shai-Hulud 2.0 attack

### DIFF
--- a/compromised-packages.txt
+++ b/compromised-packages.txt
@@ -794,6 +794,7 @@
 @quick-start-soft/quick-task-refine:1.4.2511142126
 @relyt/claude-context-core:0.1.1
 @relyt/claude-context-mcp:0.1.1
+@relyt/mcp-server-relytone:0.0.3
 @rxap/ngx-bootstrap:19.0.3
 @rxap/ngx-bootstrap:19.0.4
 @sameepsi/sor2:2.0.2
@@ -1295,6 +1296,7 @@ hyper-fullfacing:1.0.3
 hyperterm-hipster:1.0.7
 ids-css:1.5.1
 ids-enterprise-mcp-server:0.0.2
+ids-enterprise-ng:20.1.6
 ids-enterprise-typings:20.1.6
 image-to-uri:1.0.1
 image-to-uri:1.0.2


### PR DESCRIPTION
> **Note:** This research was conducted with AI assistance.

## Summary
- Add `@relyt/mcp-server-relytone:0.0.3`
- Add `ids-enterprise-ng:20.1.6`

## Evidence

Both packages had compromised versions published on **November 24, 2025** and were subsequently unpublished from npm:

### @relyt/mcp-server-relytone:0.0.3
- Published: `2025-11-24T10:02:04.143Z`
- Status: Version exists in npm registry `time` metadata but NOT in `versions` object (unpublished)
- Related packages already in list: `@relyt/claude-context-core`, `@relyt/claude-context-mcp`

### ids-enterprise-ng:20.1.6
- Published: `2025-11-24T14:01:19.446Z`  
- Status: Version exists in npm registry `time` metadata but NOT in `versions` object (unpublished)
- Related packages already in list: `ids-enterprise-mcp-server`, `ids-enterprise-typings`

## Verification Commands

```bash
# Check @relyt/mcp-server-relytone - shows 0.0.3 was unpublished
curl -s "https://registry.npmjs.org/@relyt%2Fmcp-server-relytone" | \
  jq '[.time | keys[]] - [.versions | keys[]] - ["created", "modified"]'
# Returns: ["0.0.3"]

# Check ids-enterprise-ng - shows 20.1.6 was unpublished  
curl -s "https://registry.npmjs.org/ids-enterprise-ng" | \
  jq '[.time | keys[]] - [.versions | keys[]] - ["created", "modified"]'
# Returns: ["18.2.1-3.1", "20.1.6", "4.11.0-dev.20180921", "4.7.0-test.1"]
```

The November 24, 2025 publish dates align with the Shai-Hulud 2.0 attack wave documented by security researchers.

## Security Reference

Both packages are listed in Wiz.io's comprehensive appendix of ~800 compromised npm packages:

- [Wiz.io - Shai-Hulud 2.0 Supply Chain Attack: 25K+ Repos Exposed](https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack)