### PR TITLE
feat: add ignore-list support for detector findings

### DIFF
--- a/ignore-auto-load/.github/workflows/shai-hulud-workflow.yml
+++ b/ignore-auto-load/.github/workflows/shai-hulud-workflow.yml
@@ -1,0 +1,12 @@
+name: ignored-shai-hulud-workflow
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Example
+        run: echo "test fixture for ignore auto-load"

--- a/ignore-auto-load/.shai-hulud-ignore
+++ b/ignore-auto-load/.shai-hulud-ignore
@@ -1,0 +1,1 @@
+.github/workflows/

--- a/ignore-auto-load/README.md
+++ b/ignore-auto-load/README.md
@@ -1,0 +1,7 @@
+# ignore-auto-load
+
+This fixture validates automatic loading of `.shai-hulud-ignore`.
+
+- It intentionally includes `.github/workflows/shai-hulud-workflow.yml` (normally HIGH risk).
+- `.shai-hulud-ignore` suppresses that workflow path by default.
+- Tests can disable auto-ignore by passing `--ignore-file /dev/null` as a control.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -197,6 +197,78 @@ fi
 # Cleanup
 rm -f "$LOG_FILE"
 
+# Test ignore-list functionality
+echo ""
+echo "========================================"
+echo "  Testing ignore list functionality"
+echo "========================================"
+
+# Test markers (path-based assertions avoid unrelated global findings)
+DISCUSSION_MARKER="discussion-workflows/.github/workflows/discussion.yaml"
+AUTO_MARKER="ignore-auto-load/.github/workflows/shai-hulud-workflow.yml"
+
+# Test 1: --ignore suppresses matching workflow file path
+ignore_result=$("$BASH_CMD" "$DETECTOR" --ignore ".github/workflows/" "$SCRIPT_DIR/test-cases/discussion-workflows" 2>&1)
+if ! echo "$ignore_result" | grep -q "$DISCUSSION_MARKER"; then
+    echo -e "${GREEN}PASS${NC}: --ignore suppresses matching workflow path output"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: --ignore did not suppress expected workflow path output"
+    ((failed++))
+fi
+((total++))
+
+# Test 2: --ignore with non-matching pattern does not suppress real findings
+ignore_nomatch_result=$("$BASH_CMD" "$DETECTOR" --ignore "definitely-no-match-pattern-12345" "$SCRIPT_DIR/test-cases/infected-project" 2>&1)
+ignore_nomatch_exit=$?
+if [[ "$ignore_nomatch_exit" -eq 1 ]] && echo "$ignore_nomatch_result" | grep -q "HIGH RISK"; then
+    echo -e "${GREEN}PASS${NC}: non-matching --ignore does not hide HIGH risk findings"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: non-matching --ignore unexpectedly changed detection behavior"
+    ((failed++))
+fi
+((total++))
+
+# Test 3: --ignore-file suppresses matching findings from file patterns
+IGNORE_FILE="/tmp/shai-hulud-ignore-$$.txt"
+echo ".github/workflows/" > "$IGNORE_FILE"
+ignore_file_result=$("$BASH_CMD" "$DETECTOR" --ignore-file "$IGNORE_FILE" "$SCRIPT_DIR/test-cases/discussion-workflows" 2>&1)
+if ! echo "$ignore_file_result" | grep -q "$DISCUSSION_MARKER"; then
+    echo -e "${GREEN}PASS${NC}: --ignore-file suppresses matching workflow path output"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: --ignore-file did not suppress expected workflow path output"
+    ((failed++))
+fi
+((total++))
+rm -f "$IGNORE_FILE"
+
+# Test 4: .shai-hulud-ignore auto-load suppresses fixture workflow path by default
+auto_ignore_result=$("$BASH_CMD" "$DETECTOR" "$SCRIPT_DIR/test-cases/ignore-auto-load" 2>&1)
+if ! echo "$auto_ignore_result" | grep -q "$AUTO_MARKER"; then
+    echo -e "${GREEN}PASS${NC}: .shai-hulud-ignore is auto-loaded"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: .shai-hulud-ignore was not auto-loaded as expected"
+    ((failed++))
+fi
+((total++))
+
+# Test 5: explicit --ignore-file path disables auto-load fallback
+EMPTY_IGNORE_FILE="/tmp/shai-hulud-empty-ignore-$$.txt"
+: > "$EMPTY_IGNORE_FILE"
+no_auto_result=$("$BASH_CMD" "$DETECTOR" --ignore-file "$EMPTY_IGNORE_FILE" "$SCRIPT_DIR/test-cases/ignore-auto-load" 2>&1)
+if echo "$no_auto_result" | grep -q "$AUTO_MARKER"; then
+    echo -e "${GREEN}PASS${NC}: explicit --ignore-file disables auto-load fallback"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: explicit --ignore-file did not override auto-load behavior"
+    ((failed++))
+fi
+((total++))
+rm -f "$EMPTY_IGNORE_FILE"
+
 echo ""
 echo "========================================"
 echo "  Final Results: $passed/$total passed, $failed failed"

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -1530,8 +1530,10 @@ check_packages() {
     # BATCH OPTIMIZATION: Extract all deps using parallel processing
     print_status "$BLUE" "   Extracting dependencies from all package.json files..."
 
-    # Create optimized lookup table from compromised packages (sorted for join)
-    awk -F: '{print $1":"$2}' $SCRIPT_DIR/compromised-packages.txt | LC_ALL=C sort > "$TEMP_DIR/compromised_lookup.txt"
+    # Create optimized lookup table from compromised packages (sorted for set intersection)
+    # NOTE: This intentionally uses the in-memory COMPROMISED_PACKAGES_MAP, so the script
+    # still works when copied without the companion compromised-packages.txt file.
+    { for pkg in "${!COMPROMISED_PACKAGES_MAP[@]}"; do echo "$pkg"; done; } | LC_ALL=C sort > "$TEMP_DIR/compromised_lookup.txt"
 
     # Extract all dependencies from all package.json files using parallel xargs + awk
     # Format: file_path|package_name:version

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -23,12 +23,21 @@ set -eo pipefail
 # Script directory for locating companion files (compromised-packages.txt)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Script filename/path (used for self-exclusion)
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_PATH="$SCRIPT_DIR/$SCRIPT_NAME"
+
 # Global temp directory for file-based storage
 TEMP_DIR=""
 
 # Global variables for risk tracking (used for exit codes)
 high_risk=0
 medium_risk=0
+
+# Ignore list support (file-path substring matches)
+# - Always ignores the detector itself to prevent self-matches when scanning a directory containing this script.
+IGNORE_FILE=""
+declare -a IGNORE_PATTERNS=()
 
 # Function: create_temp_dir
 # Purpose: Create cross-platform temporary directory for findings storage
@@ -428,6 +437,9 @@ usage() {
     echo "  --parallelism N    Set the number of threads to use for parallelized steps (current: ${PARALLELISM})"
     echo "  --save-log FILE    Save all detected file paths to FILE, grouped by severity"
     echo "                     Output format: # HIGH / # MEDIUM / # LOW headers with file paths"
+    echo "  --ignore-file FILE Load ignore patterns from FILE (one per line, '#' comments)"
+    echo "                     If <directory_to_scan> contains .shai-hulud-ignore, it is loaded automatically"
+    echo "  --ignore PATTERN   Ignore any file/finding where the path contains PATTERN (repeatable)"
     echo ""
     echo "GREP TOOL SELECTION (auto-selects fastest available by default: git-grep > ripgrep > grep):"
     echo "  --use-git-grep     Force use of git grep (fastest, DFA-based, no backtracking)"
@@ -438,6 +450,8 @@ usage() {
     echo "  $0 /path/to/your/project                    # Core Shai-Hulud detection only"
     echo "  $0 --paranoid /path/to/your/project         # Core + advanced security checks"
     echo "  $0 --save-log report.log /path/to/project   # Save findings to file"
+    echo "  $0 --ignore-file .shai-hulud-ignore /path/to/project   # Suppress known-safe matches"
+    echo "  $0 --ignore node_modules/ /path/to/project              # Ignore noisy directories"
     echo "  $0 --use-ripgrep /path/to/your/project      # Force ripgrep for testing"
     exit 1
 }
@@ -451,6 +465,215 @@ print_status() {
     local color=$1
     local message=$2
     echo -e "${color}${message}${NC}"
+}
+
+# =============================================================================
+# Ignore List Helpers
+# =============================================================================
+
+# Function: trim_whitespace
+# Purpose: Normalize input by removing CRLF and trimming leading/trailing whitespace
+# Args: $1 = raw input string
+# Modifies: None
+# Returns: Prints normalized string to stdout
+trim_whitespace() {
+    local s="${1:-}"
+    s="${s//$'\r'/}"
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+# Function: add_ignore_pattern
+# Purpose: Add a single ignore pattern to IGNORE_PATTERNS after normalization
+# Args: $1 = ignore pattern substring
+# Modifies: IGNORE_PATTERNS array
+# Returns: 0 (no-op for empty patterns)
+add_ignore_pattern() {
+    local pattern
+    pattern=$(trim_whitespace "${1:-}")
+    [[ -z "$pattern" ]] && return 0
+
+    # Drop leading "./" for convenience
+    while [[ "$pattern" == "./"* ]]; do
+        pattern="${pattern#./}"
+    done
+
+    IGNORE_PATTERNS+=("$pattern")
+}
+
+# Function: load_ignore_file
+# Purpose: Load ignore patterns from a file, skipping blanks and comments
+# Args: $1 = path to ignore file
+# Modifies: IGNORE_PATTERNS array
+# Returns: 0 (safe no-op when file does not exist)
+load_ignore_file() {
+    local ignore_file="$1"
+    [[ -f "$ignore_file" ]] || return 0
+
+    while IFS= read -r line; do
+        line=$(trim_whitespace "$line")
+        [[ -z "$line" ]] && continue
+        [[ "$line" == \#* ]] && continue
+        add_ignore_pattern "$line"
+    done < "$ignore_file" || true
+}
+
+# Function: init_ignore_patterns
+# Purpose: Initialize effective ignore patterns from defaults, file, and CLI flags
+# Args: $1 = scan directory, $2 = optional ignore file, $@ = extra CLI patterns
+# Modifies: IGNORE_PATTERNS array, IGNORE_FILE
+# Returns: 0 on success, exits on invalid ignore-file path
+init_ignore_patterns() {
+    local scan_dir="$1"
+    local ignore_file="$2"
+    shift 2 || true
+
+    IGNORE_PATTERNS=()
+    add_ignore_pattern "$SCRIPT_NAME"
+    add_ignore_pattern "$SCRIPT_PATH"
+
+    if [[ -n "$ignore_file" ]]; then
+        if [[ ! -f "$ignore_file" ]]; then
+            print_status "$RED" "Error: Ignore file '$ignore_file' does not exist."
+            exit 1
+        fi
+        IGNORE_FILE="$ignore_file"
+        load_ignore_file "$ignore_file"
+    else
+        local auto_ignore_file="$scan_dir/.shai-hulud-ignore"
+        if [[ -f "$auto_ignore_file" ]]; then
+            IGNORE_FILE="$auto_ignore_file"
+            load_ignore_file "$auto_ignore_file"
+        else
+            IGNORE_FILE=""
+        fi
+    fi
+
+    local pattern
+    for pattern in "$@"; do
+        add_ignore_pattern "$pattern"
+    done
+}
+
+# Function: is_ignored_path
+# Purpose: Check whether a path should be ignored based on substring matching
+# Args: $1 = candidate file path
+# Modifies: None
+# Returns: 0 if ignored, 1 otherwise
+is_ignored_path() {
+    local candidate_path="$1"
+    local pattern
+
+    for pattern in "${IGNORE_PATTERNS[@]}"; do
+        [[ -z "$pattern" ]] && continue
+        if [[ "$candidate_path" == *"$pattern"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Function: filter_lines_file_in_place
+# Purpose: Remove ignored paths from a findings/inventory file in-place
+# Args: $1 = file containing one path-based entry per line
+# Modifies: Rewrites target file (temporary file + atomic move)
+# Returns: 0 when complete or when file/pattern set is empty
+filter_lines_file_in_place() {
+    local file="$1"
+    [[ -f "$file" ]] || return 0
+    [[ ${#IGNORE_PATTERNS[@]} -gt 0 ]] || return 0
+
+    local tmp="${file}.tmp"
+    : > "$tmp"
+
+    while IFS= read -r line; do
+        line="${line//$'\r'/}"
+        [[ -z "$line" ]] && continue
+
+        local path="${line%%:*}"
+        if is_ignored_path "$path"; then
+            continue
+        fi
+
+        echo "$line" >> "$tmp"
+    done < "$file" || true
+
+    mv "$tmp" "$file"
+}
+
+# Function: apply_ignore_filters_to_inventory
+# Purpose: Apply ignore filtering to all precomputed inventory/cache file lists
+# Args: None (uses TEMP_DIR and IGNORE_PATTERNS)
+# Modifies: Inventory files in TEMP_DIR
+# Returns: 0 after filtering all known inventory files
+apply_ignore_filters_to_inventory() {
+    local inventory_files=(
+        "$TEMP_DIR/all_files_raw.txt"
+        "$TEMP_DIR/package_files.txt"
+        "$TEMP_DIR/code_files.txt"
+        "$TEMP_DIR/yaml_files.txt"
+        "$TEMP_DIR/script_files.txt"
+        "$TEMP_DIR/lockfiles.txt"
+        "$TEMP_DIR/workflow_files_found.txt"
+        "$TEMP_DIR/setup_bun_files.txt"
+        "$TEMP_DIR/bun_environment_files.txt"
+        "$TEMP_DIR/actions_secrets_found.txt"
+        "$TEMP_DIR/obfuscated_exfil_found.txt"
+        "$TEMP_DIR/trufflehog_files.txt"
+        "$TEMP_DIR/formatter_workflows.txt"
+        "$TEMP_DIR/github_workflows.txt"
+        "$TEMP_DIR/git_repos.txt"
+        "$TEMP_DIR/suspicious_dirs.txt"
+    )
+
+    local f
+    for f in "${inventory_files[@]}"; do
+        filter_lines_file_in_place "$f"
+    done
+}
+
+# Function: apply_ignore_filters_to_findings
+# Purpose: Apply ignore filtering to all generated findings output files
+# Args: None (uses TEMP_DIR and IGNORE_PATTERNS)
+# Modifies: Findings files in TEMP_DIR
+# Returns: 0 after filtering all known findings files
+apply_ignore_filters_to_findings() {
+    local finding_files=(
+        "$TEMP_DIR/workflow_files.txt"
+        "$TEMP_DIR/malicious_hashes.txt"
+        "$TEMP_DIR/compromised_found.txt"
+        "$TEMP_DIR/suspicious_found.txt"
+        "$TEMP_DIR/suspicious_content.txt"
+        "$TEMP_DIR/crypto_patterns.txt"
+        "$TEMP_DIR/git_branches.txt"
+        "$TEMP_DIR/postinstall_hooks.txt"
+        "$TEMP_DIR/trufflehog_activity.txt"
+        "$TEMP_DIR/shai_hulud_repos.txt"
+        "$TEMP_DIR/namespace_warnings.txt"
+        "$TEMP_DIR/integrity_issues.txt"
+        "$TEMP_DIR/typosquatting_warnings.txt"
+        "$TEMP_DIR/network_exfiltration_warnings.txt"
+        "$TEMP_DIR/lockfile_safe_versions.txt"
+        "$TEMP_DIR/bun_setup_files.txt"
+        "$TEMP_DIR/bun_environment_files.txt"
+        "$TEMP_DIR/new_workflow_files.txt"
+        "$TEMP_DIR/github_sha1hulud_runners.txt"
+        "$TEMP_DIR/preinstall_bun_patterns.txt"
+        "$TEMP_DIR/malicious_repo_descriptions.txt"
+        "$TEMP_DIR/actions_secrets_files.txt"
+        "$TEMP_DIR/obfuscated_exfil_files.txt"
+        "$TEMP_DIR/discussion_workflows.txt"
+        "$TEMP_DIR/sandworm_mode_workflows.txt"
+        "$TEMP_DIR/github_runners.txt"
+        "$TEMP_DIR/destructive_patterns.txt"
+        "$TEMP_DIR/trufflehog_patterns.txt"
+    )
+
+    local f
+    for f in "${finding_files[@]}"; do
+        filter_lines_file_in_place "$f"
+    done
 }
 
 # =============================================================================
@@ -2972,6 +3195,8 @@ main() {
     local paranoid_mode=false
     local scan_dir=""
     local save_log=""
+    local ignore_file=""
+    local -a ignore_patterns=()
 
     # Load compromised packages from external file
     load_compromised_packages
@@ -3009,6 +3234,22 @@ main() {
                     usage
                 fi
                 save_log="$2"
+                shift
+                ;;
+            --ignore-file)
+                if [[ -z "$2" || "$2" == -* ]]; then
+                    echo "${RED}error: --ignore-file requires a file path${NC}" >&2;
+                    usage
+                fi
+                ignore_file="$2"
+                shift
+                ;;
+            --ignore)
+                if [[ -z "$2" || "$2" == -* ]]; then
+                    echo "${RED}error: --ignore requires a pattern${NC}" >&2;
+                    usage
+                fi
+                ignore_patterns+=("$2")
                 shift
                 ;;
             --use-git-grep)
@@ -3062,6 +3303,9 @@ main() {
     # Select grep tool (auto-detect or use flag override)
     select_grep_tool
 
+    # Initialize ignore patterns (also excludes this detector script from scans)
+    init_ignore_patterns "$scan_dir" "$ignore_file" "${ignore_patterns[@]}"
+
     # Initialize timing
     SCAN_START_TIME=$(date +%s%N 2>/dev/null || echo "$(date +%s)000000000")
 
@@ -3076,6 +3320,9 @@ main() {
     # Collect all files in a single pass for performance optimization
     print_status "$ORANGE" "[Stage 1/6] Collecting file inventory for analysis"
     collect_all_files "$scan_dir"
+
+    # Apply ignore filters to the collected inventory (prevents self-matches and supports user ignore lists)
+    apply_ignore_filters_to_inventory
 
     # Show summary of collected files
     local total_files=$(wc -l < "$TEMP_DIR/all_files_raw.txt" 2>/dev/null || echo "0")
@@ -3128,6 +3375,9 @@ main() {
         check_network_exfiltration "$scan_dir"
         print_stage_complete "Paranoid mode checks"
     fi
+
+    # Apply ignore filters to any generated findings (covers checks that do not use the inventory lists)
+    apply_ignore_filters_to_findings
 
     # Generate report
     print_status "$BLUE" "Generating report..."


### PR DESCRIPTION
## Summary
This PR adds first-class ignore/suppression support to the detector so users can reduce noise from known-safe files and false positives without changing detection logic.

### What changed
- Added `--ignore-file FILE` support
  - Loads ignore patterns (one per line, `#` comments supported).
- Added repeatable `--ignore PATTERN` support
  - Suppresses findings/paths when the file path contains the provided substring.
- Added automatic `.shai-hulud-ignore` loading
  - If present in the scan target directory, it is loaded automatically when `--ignore-file` is not provided.
- Added self-exclusion defaults
  - Detector script path/name is auto-ignored to avoid self-matches.
- Applied ignore filtering in two phases
  - Inventory phase (`collect_all_files` outputs)
  - Findings phase (all risk/finding output files)
- Added full function-style comments for newly added helper functions to match project style.
- Added follow-up fix: check_packages() now builds compromised_lookup.txt from COMPROMISED_PACKAGES_MAP instead of re-reading compromised-packages.txt, improving portability for standalone script use.

### New helper functions
- `trim_whitespace`
- `add_ignore_pattern`
- `load_ignore_file`
- `init_ignore_patterns`
- `is_ignored_path`
- `filter_lines_file_in_place`
- `apply_ignore_filters_to_inventory`
- `apply_ignore_filters_to_findings`

## Test Coverage Added
Added dedicated ignore behavior tests in `run-tests.sh` plus a new fixture:

- New fixture:
  - `test-cases/ignore-auto-load/.github/workflows/shai-hulud-workflow.yml`
  - `test-cases/ignore-auto-load/.shai-hulud-ignore`
  - `test-cases/ignore-auto-load/README.md`

- New ignore tests:
  1. `--ignore` suppresses matching workflow path output
  2. Non-matching `--ignore` does not hide real HIGH findings
  3. `--ignore-file` suppresses matching workflow path output
  4. `.shai-hulud-ignore` auto-load is applied by default
  5. Explicit `--ignore-file` overrides auto-load fallback

## Validation
- `bash -n shai-hulud-detector.sh` ✅
- `bash -n run-tests.sh` ✅
- `bash run-tests.sh`:
  - Core suite: `32/35` passed
  - `--save-log` checks: `3/3` passed
  - New ignore checks: `5/5` passed
  - Final: `40/43` passed

## Notes on Existing Baseline Failures
The same 3 known failing cases also fail on upstream baseline and are not introduced by this PR:
- `discussion-workflows`
- `github-actions-runners`
- `infected-lockfile-pnpm`

## Why this is useful
Teams can now keep detector signal high in real repositories by suppressing known-safe paths and recurring false positives in a transparent, auditable way (`.shai-hulud-ignore` and CLI flags), while preserving default detection behavior.