### PR TITLE
Fix git-grep backend silently disabling all content-pattern checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the Shai-Hulud NPM Supply Chain Attack Detector will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.2] - 2026-08-05
+
+### Fixed
+- **The `git-grep` backend silently returned no matches, disabling every content-pattern check.** `git grep --no-index` only accepts pathspecs inside the directory tree it runs from and rejects absolute paths outright (`fatal: '…' is outside the directory tree` / `is outside repository`). `main()` resolves the scan directory to an absolute path (`scan_dir=$(cd "$scan_dir" && pwd)`), so every path handed to the `fast_grep_*` helpers was absolute. Those helpers discard git's stderr (`2>/dev/null || true`), so the failure surfaced as *zero findings* rather than an error.
+  - **Impact:** git-grep is auto-selected whenever `git` is installed, i.e. the default on virtually every developer machine and CI runner. All ~20 content-matching checks — `check_keyv_indicators`, `check_network_exfiltration`, `check_crypto_theft_patterns`, `check_trufflehog_activity`, `check_destructive_patterns`, `check_ai_assistant_dropper`, `check_mini_shai_hulud_indicators`, and every other campaign-specific `check_*_indicators` (84 call sites) — reported clean on infected trees. Package-list, lockfile, hash and preinstall-hook detection were unaffected, as they use awk/bash lookups rather than the grep helpers.
+  - The bug only stayed hidden because CWD-inside-a-git-repo-containing-the-target is the one case git grep accepts, which is exactly how the test suite invokes the detector (fixtures live under the detector's own repository). Running the documented `cd shai-hulud-detect && ./shai-hulud-detector.sh ~/project` lost the checks.
+  - **Fix:** the git-grep backend now runs as `git -C "$GREP_BASE" grep` with paths relativized against the scan root (`grep_paths_to_base`) and re-absolutized on output (`grep_paths_from_base`), so callers keep receiving the absolute paths the reports, `--save-log` and `--json` contracts assume. Verified that explicit pathspecs are still searched regardless of `.gitignore`, so `node_modules/` coverage is retained.
+  - Relativized pathspecs are emitted with a `./` prefix. Without it a scanned file literally named `:!<something>` would be parsed as git **pathspec magic** — `:!` is the exclude prefix — letting a malicious package ship one extra file to silently drop another from every content search. `./` forces literal interpretation.
+  - The scan root reaches `awk` through the environment, not `awk -v`. `-v` assignments undergo escape-sequence processing, so a scan path containing a backslash (`/tmp/we\ird`) arrived as `/tmp/weird`, matched nothing, and degraded every search back to the original bug.
+  - A scan root of `/` (reachable via `--bulk /`, a mounted volume root, or a container scan) no longer produces a `//` prefix that matches nothing.
+- **`--check-host` could not read `$HOME/.claude/settings.json` on the git-grep backend.** The Nx Console persistence marker lives outside the scan root and is not addressable as a git pathspec at all, so the check silently never fired. `fast_grep_quiet` now falls back to plain grep for paths outside the base. The batch helpers divert such paths to a plain-grep pass as well: git aborts the entire invocation on the first unusable pathspec, so a single out-of-base path in a batch would discard results for every other file batched with it. No batch list contains one today — every entry comes from `find "$scan_dir"` — but the diversion keeps that from becoming a silent failure if one ever does.
+- **Auto-selection now verifies the backend before trusting it.** `select_grep_tool` probes git grep against the actual scan root once per run (`git_grep_backend_works`) — searching one real file for a sentinel that cannot match, so exit 1 means "works" and 128 means "cannot address this tree" — and falls back to ripgrep/grep otherwise. Probing the scan root rather than a scratch directory is what makes pathspec-addressability failures visible at all. An explicit `--use-git-grep` is verified too and downgraded with a printed note: silently reporting a compromised tree as clean is worse than not honouring the flag.
+
+### Added
+- **Backend-parity regression tests** (`run-tests.sh`): scan out-of-tree fixtures in `$TMPDIR` from a neutral working directory and assert that all four backends (auto, `--use-git-grep`, `--use-ripgrep`, `--use-grep`) report the `npm-cache.com` C2 domain, that a `:!`-prefixed decoy file cannot suppress a finding, that a backslash in the scan path does not disable content checks, and that `--check-host` still reads `$HOME`. The block asserts its own precondition (`$TMPDIR` outside any git repository) and skips rather than passing vacuously, since that arrangement is exactly what hid the bug. All five git-grep assertions fail on the unpatched code. Suite: 238 → 245 checks.
+
+### Changed
+- **`shai-hulud-detector.sh`**: `SCRIPT_VERSION` 3.14.1 → 3.14.2.
+- **`README.md`**: tests badge/count 238 → 245.
+
+### Notes
+- **Backend timings after the fix** (macOS, warm cache). Large trees still favour git-grep, which is why it remains the auto-selected default; small trees are dominated by per-invocation process startup, where git is the heaviest of the three. Measured on a 3,001-file tree: git-grep 32.4 s, ripgrep 40.1 s, grep 42.2 s. On a 2-file tree: grep 2.0 s, ripgrep 2.5 s, git-grep 3.2 s. The small-tree ordering is not a regression introduced here — the previous git-grep path was "fast" only because it aborted without searching anything.
+
 ## [3.14.1] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Shell](https://img.shields.io/badge/shell-Bash%205.0%2B-blue)](#requirements)
 [![Status](https://img.shields.io/badge/status-Active-success)](../../)
-[![Tests](https://img.shields.io/badge/tests-238%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-245%20passing-brightgreen)](#testing)
 [![Packages](https://img.shields.io/badge/compromised%20packages-3%2C460%2B-red)](compromised-packages.txt)
 [![Type](https://img.shields.io/badge/type-Security%20Tool-red)](#what-it-catches)
 [![Contributions](https://img.shields.io/badge/contributions-Welcome-orange)](#contributing)
@@ -253,7 +253,7 @@ To add new packages from a fresh advisory: append entries in that format, run `.
 ## Testing
 
 ```bash
-./run-tests.sh                          # full suite, 238 checks
+./run-tests.sh                          # full suite, 245 checks
 ./shai-hulud-detector.sh test-cases/<fixture-name>   # run one fixture manually
 ```
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -648,6 +648,126 @@ done
 rm -rf "$XARGS_TMP"
 
 # ============================================================
+#  Backend parity: every grep tool must find the same content IoCs
+# ============================================================
+# `git grep --no-index` refuses absolute pathspecs, and main() resolves the scan
+# directory to an absolute path before collecting files. The fast_grep_* helpers
+# discard git's stderr (`2>/dev/null || true`), so on the git-grep backend every
+# content-pattern check (~20 functions: C2 domains, network exfiltration, crypto
+# theft, trufflehog, destructive payloads, …) silently returned NOTHING and the
+# scan reported clean.
+#
+# The bug is invisible to the rest of this suite because the fixtures live under
+# $SCRIPT_DIR, and running from inside the detector's own git repository happens
+# to be the one case where git grep accepts the paths. This test therefore uses an
+# out-of-tree fixture in $TMPDIR and runs from a neutral working directory — the
+# way CI and `cd shai-hulud-detect && ./shai-hulud-detector.sh ~/project` behave.
+BACKEND_TMP=$(mktemp -d)
+mkdir -p "$BACKEND_TMP/proj/node_modules/keyv"
+# npm-cache.com is the Aug 4, 2026 keyv/cacheable C2 fallback (check_keyv_indicators).
+# Inert string constants throughout this block — no executable payload, per the
+# fixture policy in README's Contributing section.
+printf 'const endpoint = "https://npm-cache.com/router";\n' \
+    > "$BACKEND_TMP/proj/node_modules/keyv/Math_Symbol.js"
+printf '{"name":"app","version":"1.0.0"}\n' > "$BACKEND_TMP/proj/package.json"
+
+# The whole point of this block is that the working directory is NOT inside a git
+# repository containing the scan target — that is the one arrangement in which git
+# grep accepts the paths, and it would turn every assertion below into a silent
+# false negative. $TMPDIR is normally outside any repo, but CI runners that set
+# TMPDIR=$GITHUB_WORKSPACE/tmp (or a dotfiles repo at $HOME) break the assumption,
+# so assert it rather than trusting it.
+if ! command -v git >/dev/null 2>&1; then
+    # --use-git-grep exits 1 outright without git, so these would FAIL rather than
+    # be skipped. The backend under test is the git one; nothing to assert here.
+    echo -e "${YELLOW}SKIP${NC}: grep backend parity - git is not installed"
+elif git -C "$BACKEND_TMP" rev-parse --show-toplevel >/dev/null 2>&1; then
+    echo -e "${YELLOW}SKIP${NC}: grep backend parity - the temp fixture directory is inside a git repository"
+else
+    for backend in "" "--use-git-grep" "--use-ripgrep" "--use-grep"; do
+        backend_label="${backend:-auto-selected}"
+        # ripgrep may not be installed on the runner; skip that backend if so.
+        if [[ "$backend" == "--use-ripgrep" ]] && ! command -v rg >/dev/null 2>&1; then
+            echo -e "${YELLOW}SKIP${NC}: grep backend parity - ripgrep is not installed"
+            continue
+        fi
+        ((total++))
+        # Run from a directory that is neither the scan target nor a git repository
+        # containing it, so absolute pathspecs are genuinely out of tree.
+        BACKEND_OUT=$(cd "$BACKEND_TMP" && "$BASH_CMD" "$DETECTOR" $backend "$BACKEND_TMP/proj" 2>&1)
+        if grep -q "npm-cache.com" <<< "$BACKEND_OUT"; then
+            echo -e "${GREEN}PASS${NC}: grep backend parity - $backend_label finds out-of-tree content IoCs"
+            ((passed++))
+        else
+            echo -e "${RED}FAIL${NC}: grep backend parity - $backend_label silently missed the npm-cache.com C2 domain"
+            ((failed++))
+        fi
+    done
+
+    # A path beginning with ":" must not be read as git pathspec magic. ":!x" is
+    # git's EXCLUDE syntax, so without the "./" prefix the backend adds, a malicious
+    # package could ship one extra path named ":!<target>" to silently drop <target>
+    # from every content search — attacker-controlled and completely silent.
+    #
+    # The decoy must be a DIRECTORY mirroring the real file's path, not a bare file:
+    # git's exclude pathspec matches from the start of the path, so a top-level
+    # ":!Math_Symbol.js" would not suppress "node_modules/keyv/Math_Symbol.js" and
+    # the assertion would pass even without the fix. Contents are inert.
+    mkdir -p "$BACKEND_TMP/proj/:!node_modules/keyv"
+    printf '// inert decoy\n' > "$BACKEND_TMP/proj/:!node_modules/keyv/Math_Symbol.js"
+    ((total++))
+    PATHSPEC_OUT=$(cd "$BACKEND_TMP" && "$BASH_CMD" "$DETECTOR" --use-git-grep "$BACKEND_TMP/proj" 2>&1)
+    if grep -q "npm-cache.com" <<< "$PATHSPEC_OUT"; then
+        echo -e "${GREEN}PASS${NC}: grep backend parity - ':!'-prefixed decoy path cannot suppress a finding"
+        ((passed++))
+    else
+        echo -e "${RED}FAIL${NC}: grep backend parity - ':!'-prefixed decoy path suppressed the npm-cache.com finding"
+        ((failed++))
+    fi
+    rm -rf "$BACKEND_TMP/proj/:!node_modules"
+
+    # A backslash in the scan path must survive the path relativization. `awk -v`
+    # applies escape-sequence processing to its assignments, so passing the base
+    # that way turns /tmp/we\ird into /tmp/weird, matches nothing, and degrades the
+    # backend right back to finding nothing at all.
+    mkdir -p "$BACKEND_TMP/we\\ird"
+    printf '{"name":"app"}\n' > "$BACKEND_TMP/we\\ird/package.json"
+    printf 'const endpoint = "https://npm-cache.com/router";\n' > "$BACKEND_TMP/we\\ird/payload.js"
+    ((total++))
+    BSLASH_OUT=$(cd "$BACKEND_TMP" && "$BASH_CMD" "$DETECTOR" --use-git-grep "$BACKEND_TMP/we\\ird" 2>&1)
+    if grep -q "npm-cache.com" <<< "$BSLASH_OUT"; then
+        echo -e "${GREEN}PASS${NC}: grep backend parity - backslash in scan path does not break relativization"
+        ((passed++))
+    else
+        echo -e "${RED}FAIL${NC}: grep backend parity - backslash in scan path silently disabled content checks"
+        ((failed++))
+    fi
+    rm -rf "$BACKEND_TMP/we\\ird"
+
+    # --check-host probes $HOME/.claude/settings.json, which is OUTSIDE the scan
+    # root and therefore not addressable as a git pathspec at all. It must fall
+    # back to plain grep rather than silently reporting the host clean.
+    mkdir -p "$BACKEND_TMP/fakehome/.claude"
+    printf '{"hooks":{"SessionStart":"firedalazer install-mcp-extension"}}\n' \
+        > "$BACKEND_TMP/fakehome/.claude/settings.json"
+    ((total++))
+    HOSTCHK_OUT=$(cd "$BACKEND_TMP" && HOME="$BACKEND_TMP/fakehome" \
+        "$BASH_CMD" "$DETECTOR" --use-git-grep --check-host "$BACKEND_TMP/proj" 2>&1)
+    # Assert on the finding text itself. "Nx Console" alone is a tautology (the
+    # progress banner always prints it) and "settings.json" appears in generic
+    # remediation advice for any AI-assistant-dropper finding.
+    if grep -qF "Suspicious hook in Claude settings" <<< "$HOSTCHK_OUT"; then
+        echo -e "${GREEN}PASS${NC}: grep backend parity - --check-host reads paths outside the scan root"
+        ((passed++))
+    else
+        echo -e "${RED}FAIL${NC}: grep backend parity - --check-host missed the Nx Console marker in \$HOME"
+        ((failed++))
+    fi
+    rm -rf "$BACKEND_TMP/fakehome"
+fi
+rm -rf "$BACKEND_TMP"
+
+# ============================================================
 #  Paranoid-mode confusable-substring regression
 # ============================================================
 # Lock in the fix for the bare-substring false positive (yarn/intern/return/modern

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPROMISED_PACKAGES_FILE="$SCRIPT_DIR/compromised-packages.txt"
 
 # Tool version (surfaced in --json output for downstream consumers)
-SCRIPT_VERSION="3.14.1"
+SCRIPT_VERSION="3.14.2"
 
 # Global temp directory for file-based storage
 TEMP_DIR=""
@@ -205,6 +205,17 @@ fi
 # Values: "git-grep", "ripgrep", "grep"
 GREP_TOOL=""
 
+# Directory the fast_grep_* helpers resolve their file arguments against, and the cached
+# prefix that relativizes a path against it. Both are set together by set_grep_base(),
+# called from main() with the resolved scan root (--bulk child scans re-invoke this
+# script, so each gets its own). `git grep --no-index` REFUSES absolute pathspecs — it
+# only accepts paths inside the directory tree it is run from — so the git-grep backend
+# runs as `git -C "$GREP_BASE" grep` with paths relativized against this base, and its
+# output re-absolutized. Empty disables relativization, which is what the unit-style
+# tests in run-tests.sh that source the helpers directly rely on.
+GREP_BASE=""
+GREP_BASE_PREFIX=""
+
 # Semver range checking (opt-in via --check-semver-ranges flag)
 CHECK_SEMVER_RANGES=false
 
@@ -212,19 +223,64 @@ CHECK_SEMVER_RANGES=false
 # Purpose: Auto-select the best available grep tool (git-grep > ripgrep > grep)
 # Called after argument parsing to allow --use-* flags to override
 select_grep_tool() {
-    # If user specified a tool via flag, use that (already set in GREP_TOOL)
+    # If the user specified a tool via flag, honour it (already set in GREP_TOOL) —
+    # except that an explicit --use-git-grep is still verified against the scan root.
+    # Silently reporting a compromised tree as clean is a worse outcome than not
+    # honouring the flag, so warn and fall through to auto-selection instead.
     if [[ -n "$GREP_TOOL" ]]; then
-        return
+        if [[ "$GREP_TOOL" == "git-grep" ]] && ! git_grep_backend_works; then
+            print_status "$YELLOW" "   Note: git grep cannot search '$GREP_BASE' in this environment; falling back to another tool."
+            GREP_TOOL=""
+        else
+            # Explicit `return 0`: a bare `return` yields the status of the preceding
+            # test, which is non-zero here and would abort the script under `set -e`.
+            return 0
+        fi
     fi
 
     # Auto-select: git-grep > ripgrep > grep
-    if [[ "$HAS_GIT_GREP" == "true" ]]; then
+    if [[ "$HAS_GIT_GREP" == "true" ]] && git_grep_backend_works; then
         GREP_TOOL="git-grep"
     elif [[ "$HAS_RIPGREP" == "true" ]]; then
         GREP_TOOL="ripgrep"
     else
         GREP_TOOL="grep"
     fi
+}
+
+# Function: git_grep_backend_works
+# Purpose: Verify that git grep can actually search GREP_BASE in THIS environment before
+#          the backend is used. Searches one real file under the scan root for a sentinel
+#          that cannot occur: a working git exits 1 ("no match"), a git that cannot
+#          address the tree exits 128.
+# Args: None (reads GREP_BASE)
+# Returns: 0 if git grep ran successfully, 1 otherwise
+# Note: A git grep that cannot search the given paths exits non-zero and prints to
+#       stderr, which the fast_grep_* helpers discard (`2>/dev/null || true`) — so the
+#       failure surfaces as "no findings" rather than an error, i.e. a scan that
+#       silently reports clean. Anything that makes git grep unusable — pathspec
+#       addressability rules, an unexpectedly old git, a tree it cannot read — must
+#       downgrade the backend, never the results. Probing the scan root rather than a
+#       scratch directory is what makes those cases visible; it costs one `find` and
+#       one `git` per run.
+git_grep_backend_works() {
+    [[ -n "$GREP_BASE" && -d "$GREP_BASE" ]] || return 1
+
+    # Any regular file will do; -quit stops at the first hit so this stays cheap even
+    # on huge trees. An empty tree has nothing to search, so the backend is moot.
+    local probe_file
+    probe_file=$(find "$GREP_BASE" -type f -print -quit 2>/dev/null) || true
+    [[ -n "$probe_file" ]] || return 1
+
+    # Explicit rc capture: `set -e` must not see the expected non-zero exit, and the
+    # distinction between the exit codes is the whole point of the probe.
+    local rc=0
+    git -C "$GREP_BASE" grep -q --no-index -F \
+        "__shai_hulud_grep_probe_no_match__" -- "$(grep_path_to_base "$probe_file")" \
+        >/dev/null 2>&1 || rc=$?
+
+    # 1 = ran fine, found nothing (expected). 128 = cannot address the tree.
+    [[ $rc -eq 1 ]]
 }
 
 # Known malicious file hashed (source: https://socket.dev/blog/ongoing-supply-chain-attack-targets-crowdstrike-npm-packages)
@@ -848,6 +904,115 @@ print_status() {
 # These helper functions provide a clean abstraction over grep tools.
 # GREP_TOOL is set by select_grep_tool() based on auto-detection or --use-* flags.
 
+# Function: set_grep_base
+# Purpose: Anchor the git-grep backend at a scan root, caching the prefix that turns an
+#          absolute path into a path relative to it.
+# Args: $1 = absolute scan root ("" to disable relativization)
+# Modifies: GREP_BASE, GREP_BASE_PREFIX
+# Note: The prefix is normally "$1/", but a root of "/" (a filesystem or volume root,
+#       reachable via `--bulk /`) must not become "//". Caching it keeps the hot single
+#       path helpers below fork-free — they run inside per-file loops.
+set_grep_base() {
+    GREP_BASE="$1"
+    if [[ -z "$GREP_BASE" ]]; then
+        GREP_BASE_PREFIX=""
+    elif [[ "$GREP_BASE" == "/" ]]; then
+        GREP_BASE_PREFIX="/"
+    else
+        GREP_BASE_PREFIX="$GREP_BASE/"
+    fi
+}
+
+# Function: grep_paths_to_base
+# Purpose: Rewrite an absolute path list on stdin into NUL-delimited, "./"-prefixed
+#          pathspecs relative to GREP_BASE, ready to pipe straight into `xargs -0`.
+# Args: $1 = optional file to divert out-of-base paths into
+#       (stdin = absolute path list, one per line; reads GREP_BASE_PREFIX)
+# Returns: NUL-delimited pathspecs on stdout
+# Note:
+#   - `git grep --no-index` rejects absolute pathspecs ("is outside the directory tree"
+#     / "is outside repository") and every path the detector collects is absolute,
+#     because main() resolves the scan directory with `cd … && pwd`.
+#   - The "./" prefix is REQUIRED, not cosmetic. git parses a leading ":" as pathspec
+#     magic, so a scanned file literally named ":!evil.js" would otherwise be read as
+#     the exclude pattern ":!evil.js" — letting a malicious package ship one extra file
+#     to silently remove another from the search. "./" forces literal interpretation.
+#   - GREP_BASE_PREFIX is passed through the environment rather than `awk -v`, because
+#     -v assignments undergo escape-sequence processing: a scan path containing a
+#     backslash (e.g. /tmp/we\ird) would arrive at awk as /tmp/weird, match nothing,
+#     and silently degrade every search back to the bug this exists to fix.
+#   - Out-of-base paths cannot be expressed as a pathspec, so they are diverted to $1
+#     (see fast_grep_* — they are searched with plain grep instead). git aborts the
+#     ENTIRE invocation on the first unusable pathspec, so leaving one in the list
+#     would silently discard results for every other file in the same xargs batch.
+#   - This emits NUL itself rather than piping through `tr`, keeping the added cost of
+#     relativization to roughly one process per call.
+grep_paths_to_base() {
+    GREP_BASE_PREFIX="$GREP_BASE_PREFIX" \
+    GREP_OUTSIDE_FILE="${1:-}" \
+    awk '
+        BEGIN {
+            prefix  = ENVIRON["GREP_BASE_PREFIX"]
+            outside = ENVIRON["GREP_OUTSIDE_FILE"]
+        }
+        index($0, prefix) == 1 { printf "./%s%c", substr($0, length(prefix) + 1), 0; next }
+        outside != ""          { print > outside }
+    '
+}
+
+# Function: grep_paths_from_base
+# Purpose: Re-absolutize the relative paths git grep prints, so callers keep seeing the
+#          absolute paths they passed in (reports, `[[ -f ]]` checks and the --save-log
+#          / --json contracts all assume absolute).
+# Args: $1 = git grep output (newline-separated relative paths)
+# Returns: Absolute path list on stdout
+# Note: Pure bash, no subprocess — git grep prints only the files that MATCHED, which is
+#       nearly always zero and never more than a handful, so a read loop is cheaper than
+#       a fork. git strips the "./" added by grep_paths_to_base, so entries arrive bare.
+grep_paths_from_base() {
+    [[ -n "$1" ]] || return 0
+    local line
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        if [[ "$line" == /* ]]; then
+            printf '%s\n' "$line"
+        else
+            printf '%s\n' "$GREP_BASE_PREFIX$line"
+        fi
+    done <<< "$1"
+}
+
+# Function: grep_path_in_base
+# Purpose: Is this single path inside GREP_BASE (and therefore expressible as a git
+#          pathspec)?
+# Args: $1 = absolute path
+# Returns: 0 if inside GREP_BASE, 1 otherwise (including when GREP_BASE is unset)
+grep_path_in_base() {
+    [[ -n "$GREP_BASE_PREFIX" && "$1" == "$GREP_BASE_PREFIX"* ]]
+}
+
+# Function: grep_path_to_base
+# Purpose: Single-path form of grep_paths_to_base. Callers must check grep_path_in_base()
+#          first; this assumes the path is inside the base.
+# Args: $1 = absolute path
+# Returns: Echoes the "./"-prefixed relative pathspec
+grep_path_to_base() {
+    printf './%s' "${1#"$GREP_BASE_PREFIX"}"
+}
+
+# Function: grep_outside_file
+# Purpose: Allocate a scratch file for grep_paths_to_base to divert out-of-base paths
+#          into. Callers must remove it.
+# Args: None
+# Returns: Echoes the path, or nothing when there is no base or no temp dir (in which
+#          case grep_paths_to_base simply drops out-of-base paths rather than feeding
+#          git a pathspec that would abort the whole batch)
+grep_outside_file() {
+    [[ -n "$GREP_BASE" && -n "${TEMP_DIR:-}" && -d "${TEMP_DIR:-}" ]] || return 0
+    local f="$TEMP_DIR/_grep_outside.$$.$RANDOM"
+    : > "$f" && printf '%s' "$f"
+}
+
 # Function: fast_grep_files
 # Purpose: Find files matching a pattern (case-sensitive)
 # Args: $1 = pattern (stdin = list of files to search)
@@ -863,8 +1028,22 @@ fast_grep_files() {
     case "$GREP_TOOL" in
         git-grep)
             # git grep uses DFA-based regex (no backtracking) - safe for complex patterns
-            # --no-index allows searching files not managed by git
-            printf '%s\n' "$input" | tr '\n' '\0' | xargs -0 git grep -l --no-index -E "$pattern" -- 2>/dev/null || true
+            # --no-index allows searching files not managed by git.
+            # Paths must be relative to GREP_BASE — see grep_paths_to_base().
+            local outside matched
+            outside="$(grep_outside_file)"
+            matched=$(printf '%s\n' "$input" | grep_paths_to_base "$outside" | \
+                xargs -0 git -C "${GREP_BASE:-.}" grep -l --no-index -E "$pattern" -- 2>/dev/null) || true
+            grep_paths_from_base "$matched"
+            if [[ -n "$outside" ]]; then
+                # Paths outside GREP_BASE are not expressible as a git pathspec, so
+                # grep_paths_to_base diverted them here. Search them with plain grep
+                # rather than dropping them.
+                if [[ -s "$outside" ]]; then
+                    tr '\n' '\0' < "$outside" | xargs -0 grep -lE "$pattern" 2>/dev/null || true
+                fi
+                rm -f "$outside"
+            fi
             ;;
         ripgrep)
             printf '%s\n' "$input" | tr '\n' '\0' | xargs -0 rg -l --no-messages -e "$pattern" 2>/dev/null || true
@@ -887,7 +1066,18 @@ fast_grep_files_i() {
     [[ -z "$input" ]] && return 0
     case "$GREP_TOOL" in
         git-grep)
-            printf '%s\n' "$input" | tr '\n' '\0' | xargs -0 git grep -li --no-index -E "$pattern" -- 2>/dev/null || true
+            local outside matched
+            outside="$(grep_outside_file)"
+            matched=$(printf '%s\n' "$input" | grep_paths_to_base "$outside" | \
+                xargs -0 git -C "${GREP_BASE:-.}" grep -li --no-index -E "$pattern" -- 2>/dev/null) || true
+            grep_paths_from_base "$matched"
+            if [[ -n "$outside" ]]; then
+                # See fast_grep_files() — out-of-base paths fall back to plain grep.
+                if [[ -s "$outside" ]]; then
+                    tr '\n' '\0' < "$outside" | xargs -0 grep -liE "$pattern" 2>/dev/null || true
+                fi
+                rm -f "$outside"
+            fi
             ;;
         ripgrep)
             printf '%s\n' "$input" | tr '\n' '\0' | xargs -0 rg -li --no-messages -e "$pattern" 2>/dev/null || true
@@ -910,7 +1100,18 @@ fast_grep_files_fixed() {
     [[ -z "$input" ]] && return 0
     case "$GREP_TOOL" in
         git-grep)
-            printf '%s\n' "$input" | tr '\n' '\0' | xargs -0 git grep -l --no-index -F "$pattern" -- 2>/dev/null || true
+            local outside matched
+            outside="$(grep_outside_file)"
+            matched=$(printf '%s\n' "$input" | grep_paths_to_base "$outside" | \
+                xargs -0 git -C "${GREP_BASE:-.}" grep -l --no-index -F "$pattern" -- 2>/dev/null) || true
+            grep_paths_from_base "$matched"
+            if [[ -n "$outside" ]]; then
+                # See fast_grep_files() — out-of-base paths fall back to plain grep.
+                if [[ -s "$outside" ]]; then
+                    tr '\n' '\0' < "$outside" | xargs -0 grep -lF "$pattern" 2>/dev/null || true
+                fi
+                rm -f "$outside"
+            fi
             ;;
         ripgrep)
             printf '%s\n' "$input" | tr '\n' '\0' | xargs -0 rg -l --no-messages --fixed-strings "$pattern" 2>/dev/null || true
@@ -930,7 +1131,16 @@ fast_grep_quiet() {
     local file="$2"
     case "$GREP_TOOL" in
         git-grep)
-            git grep -q --no-index -E "$pattern" -- "$file" 2>/dev/null
+            # Not every caller passes a path under the scan root: --check-host probes
+            # $HOME/.claude/settings.json for the Nx Console persistence marker. git
+            # grep cannot address those at all, and its failure is indistinguishable
+            # from "no match" here, so fall back to plain grep instead.
+            if grep_path_in_base "$file"; then
+                git -C "${GREP_BASE:-.}" grep -q --no-index -E "$pattern" \
+                    -- "$(grep_path_to_base "$file")" 2>/dev/null
+            else
+                grep -qE "$pattern" "$file" 2>/dev/null
+            fi
             ;;
         ripgrep)
             rg -q "$pattern" "$file" 2>/dev/null
@@ -7017,6 +7227,10 @@ main() {
         print_status "$RED" "Error: Unable to access directory '$scan_dir' or convert to absolute path."
         exit 1
     fi
+
+    # Anchor the fast_grep_* helpers at the resolved scan root. Must happen before
+    # select_grep_tool so the git-grep probe and every later search share one base.
+    set_grep_base "$scan_dir"
 
     # Select grep tool (auto-detect or use flag override)
     select_grep_tool


### PR DESCRIPTION
## The bug

`git grep --no-index` only accepts pathspecs inside the directory tree it runs from, and rejects absolute paths outright:

```
$ git grep -l --no-index -F npm-cache.com -- /tmp/proj/node_modules/keyv/Math_Symbol.js
fatal: '/tmp/proj/node_modules/keyv/Math_Symbol.js' is outside the directory tree
$ echo $?
128
```

`main()` resolves the scan directory to an absolute path (`scan_dir=$(cd "$scan_dir" && pwd)`), so every path handed to the `fast_grep_*` helpers is absolute. Those helpers discard git's stderr (`2>/dev/null || true`), so the failure surfaces as **zero findings** rather than an error.

git-grep is auto-selected whenever `git` is installed, i.e. the default on virtually every developer machine and CI runner.

### Impact

All 20 content-matching check functions (84 call sites) reported clean on infected trees — `check_keyv_indicators`, `check_network_exfiltration`, `check_crypto_theft_patterns`, `check_trufflehog_activity`, `check_destructive_patterns`, `check_ai_assistant_dropper`, `check_mini_shai_hulud_indicators`, and every other campaign-specific `check_*_indicators`.

Package-list, lockfile, hash and preinstall-hook detection were **not** affected — they use awk/bash lookups rather than the grep helpers.

Reproduction on `main`, infected fixture with the Aug 4 keyv C2 domain in `node_modules/keyv/Math_Symbol.js`:

```
--use-grep      -> 2 HIGH  (npm-cache.com C2 + preinstall hook)
--use-ripgrep   -> 2 HIGH
--use-git-grep  -> 1 HIGH  (C2 domain silently missed)   <- the default
```

### Why the suite didn't catch it

CWD-inside-a-git-repo-containing-the-target is the one arrangement where git grep accepts the paths — which is exactly how `run-tests.sh` invokes the detector, since the fixtures live under `$SCRIPT_DIR`. The README's own `cd shai-hulud-detect && ./shai-hulud-detector.sh ~/project` loses the checks.

## The fix

The git-grep backend now runs as `git -C "$GREP_BASE" grep` with paths relativized against the scan root and re-absolutized on output, so callers keep receiving the absolute paths the reports, `--save-log` and `--json` contracts assume. I verified explicit pathspecs are still searched regardless of `.gitignore`, so `node_modules/` coverage is retained.

Three hazards the relativization itself introduces are handled explicitly:

- **`./` prefix on every pathspec.** Without it, a scanned path named `:!<target>` is parsed as git pathspec magic — `:!` is the *exclude* prefix — letting a malicious package ship one extra directory to silently remove another from every content search. Attacker-controlled and completely silent; there is a regression test.
- **Scan root passed via the environment, not `awk -v`.** `-v` assignments undergo escape-sequence processing, so a scan path containing a backslash (`/tmp/we\ird`) arrived as `/tmp/weird`, matched nothing, and degraded straight back to the original bug.
- **A scan root of `/`** (reachable via `--bulk /`, a mounted volume root, or a container scan) no longer produces a `//` prefix that matches nothing.

Two further items:

- **`--check-host` never fired on this backend.** It reads `$HOME/.claude/settings.json` for the Nx Console persistence marker; that path is outside the scan root and not addressable as a git pathspec at all. `fast_grep_quiet` now falls back to plain grep for out-of-base paths. The batch helpers divert such paths the same way, because git aborts the *entire* invocation on the first unusable pathspec and would discard results for every other file batched with it. No batch list contains one today — every entry comes from `find "$scan_dir"` — but this keeps it from becoming a silent failure if one ever does.
- **`select_grep_tool` now verifies the backend before trusting it.** `git_grep_backend_works` searches one real file under the scan root for a sentinel that cannot match, so exit 1 means "works" and 128 means "cannot address this tree". Probing the scan root rather than a scratch directory is what makes addressability failures visible. An explicit `--use-git-grep` is verified too and downgraded with a printed note — silently reporting a compromised tree as clean seemed worse than not honouring the flag, but say the word if you'd rather the flag be absolute.

## Tests

Seven backend-parity assertions scanning out-of-tree fixtures from a neutral working directory. **Five fail on unpatched `main`:**

```
FAIL: auto-selected silently missed the npm-cache.com C2 domain
FAIL: --use-git-grep silently missed the npm-cache.com C2 domain
PASS: --use-ripgrep finds out-of-tree content IoCs
PASS: --use-grep finds out-of-tree content IoCs
FAIL: ':!'-prefixed decoy path suppressed the npm-cache.com finding
FAIL: backslash in scan path silently disabled content checks
FAIL: --check-host missed the Nx Console marker in $HOME
```

The block asserts its own precondition (`$TMPDIR` outside any git repository, and `git` installed) and **skips rather than passing vacuously** — a silently-rotting guard here would be worse than no guard, since that arrangement is exactly what hid the original bug.

Suite: 238 → 245 checks, `./run-tests.sh` passes 245/245. Fixtures are inert string constants generated at runtime, per the fixture policy.

## Performance

git-grep remains the auto-selected default because it still wins on large trees. Measured on macOS, warm cache:

| tree | git-grep | ripgrep | grep |
|---|---|---|---|
| 3,001 files | **32.4 s** | 40.1 s | 42.2 s |
| 2 files | 3.2 s | 2.5 s | **2.0 s** |

The small-tree ordering is process-startup dominated and is **not** a regression introduced here — the previous git-grep path was "fast" only because it aborted without searching anything. Relativization adds roughly one process per call: `grep_paths_to_base` emits NUL-delimited output directly, replacing the `tr` the pipeline already ran, and re-absolutization is done in-shell since git grep only prints the handful of files that matched.

## Sources

No external advisory — this is an internally-found defect. Everything above is reproducible with the commands shown; the `fatal: … is outside the directory tree` behaviour is git's documented pathspec handling for `--no-index` (verified on git 2.54.0).