### PR TITLE
Stop flagging every AI SDK as a durabletask C2 reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Shai-Hulud NPM Supply Chain Attack Detector will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.1] - 2026-08-05
+
+### Fixed
+- **`check_durabletask_indicators` reported HIGH RISK on any machine with an AI CLI installed.** The May 19, 2026 durabletask campaign fetches its stage-2 payload from `check.git-service.com` using the endpoints `/api/public/version`, `/v1/models` and `/audio.mp3`, and 3.5.0 matched those paths as **bare literals**. They are ordinary URL paths: `/v1/models` is the standard OpenAI- and Gemini-compatible inference endpoint, so it appears in every AI SDK and in vendored typings for them.
+  - Observed on a stock developer machine: scanning `npm root -g` flagged `@google/gemini-cli`'s bundled `googleapis` typings (`build/src/apis/ml/v1.d.ts`) as a durabletask C2 reference, attaching the campaign's remediation text — *"rotate AWS/GCP/Azure/Kubernetes/Vault/GitHub credentials, audit AWS SSM + kubectl exec history for lateral movement"*. A signal that fires on essentially every developer machine carries no information, and sending teams into credential rotation over it is worse than not having the check.
+  - **The endpoints are now reported only when the same file carries another campaign marker** (`check.git-service`, `t.m-kosche`, `rope.pyz`, `pgmonitor`, `pgsql-monitor`, `sys-update-check`, one of the three beacon strings, or `durabletask`). This deliberately preserves the one case a bare match caught and the C2 host literal does not: a variant that **rotates the C2 domain** while keeping the endpoints.
+  - **Known residual gap:** a rotated C2 host with no other campaign marker anywhere in the same file is no longer reported by this check. The wave's `rope.pyz` hash, `pgsql-monitor.service` / `pgmonitor.py` / `~/.cache/.sys-update-check*` persistence artifacts, beacon strings and pinned `durabletask` versions all still apply, so the campaign remains covered by five independent signals.
+
+### Added
+- **`test-cases/durabletask-endpoint-fp/`**: benign AI SDK client code using `/v1/models`, `/api/public/version` and `/audio.mp3`, which must stay clean. Plus an inline assertion in `run-tests.sh` covering the corroborated case (rotated C2 host + endpoint + campaign marker in one file), so the false-positive fix cannot silently become a false-negative. Suite: 238 → 241 checks.
+
+### Changed
+- **`shai-hulud-detector.sh`**: `SCRIPT_VERSION` 3.14.1 → 3.15.1.
+- **`README.md`**: tests badge/count 238 → 241.
+
 ## [3.14.1] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Shell](https://img.shields.io/badge/shell-Bash%205.0%2B-blue)](#requirements)
 [![Status](https://img.shields.io/badge/status-Active-success)](../../)
-[![Tests](https://img.shields.io/badge/tests-238%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-241%20passing-brightgreen)](#testing)
 [![Packages](https://img.shields.io/badge/compromised%20packages-3%2C460%2B-red)](compromised-packages.txt)
 [![Type](https://img.shields.io/badge/type-Security%20Tool-red)](#what-it-catches)
 [![Contributions](https://img.shields.io/badge/contributions-Welcome-orange)](#contributing)
@@ -253,7 +253,7 @@ To add new packages from a fresh advisory: append entries in that format, run `.
 ## Testing
 
 ```bash
-./run-tests.sh                          # full suite, 238 checks
+./run-tests.sh                          # full suite, 241 checks
 ./shai-hulud-detector.sh test-cases/<fixture-name>   # run one fixture manually
 ```
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -81,6 +81,8 @@ declare -A EXPECTED=(
     ["sl4x0-attack"]="1|yes|no|no"             # HIGH: sl4x0 dependency-confusion campaign (oc-aa-module-client@9.9.10 + C2 oob.sl4x0.xyz + @sl4x0.xyz publisher fingerprint + slaxorg fab org + hex-named helpers b02e30.js / 6ad264.js)
     ["art-template-attack"]="1|yes|no|no"      # HIGH: 2025-2026 art-template npm hijack (art-template@4.13.5 + iOS exploit-kit C2 v3.jiathis.com / utaq.cfww.shop / l1ewsu3yjkqeroy.xyz + threat-actor goofychris/daughtrymom)
     ["durabletask-attack"]="1|yes|no|no"       # HIGH: May 19, 2026 durabletask PyPI compromise (pypi:durabletask@1.4.1 + C2 check.git-service.com + secondary t.m-kosche.com + FIRESCALE/BABA-YAGA-KOSCHEI beacons + pgsql-monitor persistence)
+    ["durabletask-endpoint-fp"]="0|no|no|no"   # Clean: benign AI SDK code using /v1/models etc. — the durabletask C2 endpoints must not fire without corroboration
+    ["durabletask-endpoint-corroborated"]="1|yes|no|no" # HIGH: rotated C2 domain + campaign endpoint + campaign marker in one file — the case corroboration exists to keep
     ["trapdoor-attack"]="1|yes|no|no"          # HIGH: May 22-25, 2026 TrapDoor (TeamPCP) multi-ecosystem crypto-stealer — npm (eth-wallet-sentinel) + PyPI (pypi:eth-security-auditor@0.1.0) + Crates (sui-move-build-helper) name matches, P-2024-001 marker, cargo-build-helper-2026 XOR key, trap-core.js payload, and the .cursorrules AI-assistant dropper
     ["laravel-lang-attack"]="1|yes|no|no"      # HIGH: May 22, 2026 Laravel-Lang Composer tag-rewrite — name match on laravel-lang/lang + /http-statuses (all tags backdoored), composer exact-version (composer:laravel-lang/lang@15.29.5), flipboxstudio.info C2 + DebugElevator/DebugChromium payload + malicious commit SHAs
     ["node-ipc-attack"]="1|yes|no|no"          # HIGH: May 14, 2026 node-ipc backdoor (node-ipc@9.1.6 + sh.azurestaticprovider.net C2 + __ntRun/key markers; node-ipc.cjs hash in MALICIOUS_HASHLIST)
@@ -332,8 +334,8 @@ for dt_check in \
     "durabletask compromised PyPI version|durabletask@1.4.1" \
     "durabletask primary C2|durabletask C2 reference (check.git-service.com)" \
     "durabletask C2 /rope.pyz|durabletask C2 reference (/rope.pyz)" \
-    "durabletask C2 /v1/models|durabletask C2 reference (/v1/models)" \
-    "durabletask C2 /api/public/version|durabletask C2 reference (/api/public/version)" \
+    "durabletask C2 /v1/models|durabletask C2 endpoint (/v1/models) alongside another campaign marker" \
+    "durabletask C2 /api/public/version|durabletask C2 endpoint (/api/public/version) alongside another campaign marker" \
     "durabletask beacon FIRESCALE|durabletask beacon string (FIRESCALE)" \
     "durabletask beacon BABA-YAGA-KOSCHEI|durabletask beacon string (BABA-YAGA-KOSCHEI)" \
     "durabletask beacon PUSH UR T3MPRR|durabletask beacon string (PUSH UR T3MPRR)" \
@@ -646,6 +648,25 @@ for helper in fast_grep_files fast_grep_files_i fast_grep_files_fixed; do
     fi
 done
 rm -rf "$XARGS_TMP"
+
+# ============================================================
+#  durabletask C2 endpoints: corroborated match must still fire
+# ============================================================
+# The endpoint paths are no longer matched bare (see test-cases/durabletask-endpoint-fp),
+# but dropping them outright would lose the one case the bare match caught and the C2
+# host literal does not: a variant that rotates the C2 domain while keeping the
+# endpoints. That case is preserved by requiring another campaign marker in the same
+# file. The EXPECTED table already asserts the fixture is HIGH; this pins the reason,
+# so the fixture cannot start passing for some unrelated finding.
+((total++))
+DTCORR_OUT=$("$BASH_CMD" "$DETECTOR" "$SCRIPT_DIR/test-cases/durabletask-endpoint-corroborated" 2>&1)
+if grep -qF "durabletask C2 endpoint (/v1/models) alongside another campaign marker" <<< "$DTCORR_OUT"; then
+    echo -e "${GREEN}PASS${NC}: durabletask C2 endpoint still fires when corroborated (rotated C2 host)"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: durabletask C2 endpoint missed a corroborated match (rotated C2 host)"
+    ((failed++))
+fi
 
 # ============================================================
 #  Paranoid-mode confusable-substring regression

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPROMISED_PACKAGES_FILE="$SCRIPT_DIR/compromised-packages.txt"
 
 # Tool version (surfaced in --json output for downstream consumers)
-SCRIPT_VERSION="3.14.1"
+SCRIPT_VERSION="3.15.1"
 
 # Global temp directory for file-based storage
 TEMP_DIR=""
@@ -2764,14 +2764,40 @@ check_durabletask_indicators() {
         for dt_indicator in \
             "check.git-service.com" \
             "check.git-service[.]com" \
-            "/api/public/version" \
-            "/v1/models" \
-            "/rope.pyz" \
-            "/audio.mp3"
+            "/rope.pyz"
         do
             fast_grep_files_fixed "$dt_indicator" < "$TEMP_DIR/_durabletask_search_files.txt" | \
                 while IFS= read -r file; do
                     echo "$file:durabletask C2 reference ($dt_indicator)" >> "$TEMP_DIR/durabletask_indicators.txt"
+                done
+        done
+
+        # IOC 1b: The campaign's C2 endpoint paths, which are only reported when the
+        # same file carries another campaign marker.
+        #
+        # These are ordinary URL paths that occur constantly in benign code —
+        # /v1/models is the standard OpenAI- and Gemini-compatible inference endpoint,
+        # so it appears in every AI SDK and in vendored typings for them. Matching them
+        # bare reported HIGH RISK ("rotate AWS/GCP/Azure/Kubernetes/Vault/GitHub
+        # credentials") on any machine with an AI CLI installed; @google/gemini-cli's
+        # bundled googleapis typings are enough to trigger it. A signal that fires on
+        # essentially every developer machine carries no information, and sending teams
+        # into credential rotation over it is worse than not having it.
+        #
+        # Requiring corroboration keeps the case a bare match would otherwise have
+        # caught and the host literal above would not: a variant that rotates the C2
+        # domain while keeping the endpoints. Known residual gap — a rotated host with
+        # no other marker anywhere in the same file is not reported here; the wave's
+        # rope.pyz hash, persistence artifacts, beacon strings and pinned package
+        # versions all still apply.
+        local dt_corroboration='check\.git-service|t\.m-kosche|rope\.pyz|pgmonitor|pgsql-monitor|sys-update-check|FIRESCALE|BABA-YAGA-KOSCHEI|PUSH UR T3MPRR|durabletask'
+        local dt_endpoint
+        for dt_endpoint in "/api/public/version" "/v1/models" "/audio.mp3"; do
+            fast_grep_files_fixed "$dt_endpoint" < "$TEMP_DIR/_durabletask_search_files.txt" | \
+                while IFS= read -r file; do
+                    if fast_grep_quiet "$dt_corroboration" "$file"; then
+                        echo "$file:durabletask C2 endpoint ($dt_endpoint) alongside another campaign marker" >> "$TEMP_DIR/durabletask_indicators.txt"
+                    fi
                 done
         done
 

--- a/test-cases/durabletask-endpoint-corroborated/README.md
+++ b/test-cases/durabletask-endpoint-corroborated/README.md
@@ -1,0 +1,14 @@
+# durabletask-endpoint-corroborated
+
+Counterpart to `durabletask-endpoint-fp`.
+
+The durabletask C2 endpoint paths are no longer matched as bare literals,
+because `/v1/models` and friends occur in every AI SDK. Dropping them outright
+would have lost the one case a bare match caught and the C2 host literal does
+not: a variant that **rotates the C2 domain** while keeping the endpoints.
+
+This fixture models exactly that — a rotated host, a campaign endpoint, and a
+campaign marker (the `durabletask` import the dropper injects into) in one
+file — and must be flagged HIGH.
+
+Inert: no payload, no real C2, no network calls. Strings only.

--- a/test-cases/durabletask-endpoint-corroborated/dropper.py
+++ b/test-cases/durabletask-endpoint-corroborated/dropper.py
@@ -1,0 +1,8 @@
+# INERT FIXTURE - models the durabletask dropper with a rotated C2 domain.
+# The host is intentionally NOT check.git-service.com, so only the endpoint
+# path plus the campaign marker below can identify it. No code executes.
+import durabletask
+
+BASE = "https://rotated-c2.example"
+STAGE2 = BASE + "/v1/models"
+HEALTH = BASE + "/api/public/version"

--- a/test-cases/durabletask-endpoint-corroborated/package.json
+++ b/test-cases/durabletask-endpoint-corroborated/package.json
@@ -1,0 +1,1 @@
+{"name":"durabletask-endpoint-corroborated","version":"1.0.0"}

--- a/test-cases/durabletask-endpoint-fp/README.md
+++ b/test-cases/durabletask-endpoint-fp/README.md
@@ -1,0 +1,18 @@
+# durabletask-endpoint-fp
+
+False-positive regression fixture for `check_durabletask_indicators`.
+
+The May 19, 2026 durabletask campaign fetches its stage-2 payload from
+`check.git-service.com` using the endpoints `/api/public/version`, `/v1/models`
+and `/audio.mp3`. Those paths were matched as bare literals, but they are
+ordinary URL paths — `/v1/models` is the standard OpenAI- and
+Gemini-compatible inference endpoint, so it appears in every AI SDK and in
+vendored typings for them.
+
+The result was a HIGH RISK finding, complete with "rotate
+AWS/GCP/Azure/Kubernetes/Vault/GitHub credentials" guidance, on any machine
+with an AI CLI installed.
+
+Everything here is ordinary benign client code and must stay clean. The
+corroborated case — a campaign marker in the same file — is asserted
+separately in `run-tests.sh`.

--- a/test-cases/durabletask-endpoint-fp/ai-client.js
+++ b/test-cases/durabletask-endpoint-fp/ai-client.js
@@ -1,0 +1,16 @@
+// Ordinary AI SDK client code. Nothing malicious here.
+const OPENAI_BASE = "https://api.openai.com";
+const GEMINI_BASE = "https://generativelanguage.googleapis.com";
+
+export async function listModels() {
+  const res = await fetch(`${OPENAI_BASE}/v1/models`);
+  return res.json();
+}
+
+export async function listGeminiModels() {
+  const res = await fetch(`${GEMINI_BASE}/v1/models`);
+  return res.json();
+}
+
+export const healthPath = "/api/public/version";
+export const chime = "/audio.mp3";

--- a/test-cases/durabletask-endpoint-fp/package.json
+++ b/test-cases/durabletask-endpoint-fp/package.json
@@ -1,0 +1,1 @@
+{"name":"durabletask-endpoint-fp","version":"1.0.0"}


### PR DESCRIPTION
## The false positive

The May 19, 2026 durabletask campaign fetches its stage-2 payload from `check.git-service.com` using the endpoints `/api/public/version`, `/v1/models` and `/audio.mp3`. `check_durabletask_indicators` matched those paths as **bare literals**:

```bash
for dt_indicator in \
    "check.git-service.com" \
    "check.git-service[.]com" \
    "/api/public/version" \
    "/v1/models" \
    "/rope.pyz" \
    "/audio.mp3"
```

`/v1/models` is the standard OpenAI- and Gemini-compatible inference endpoint. It appears in every AI SDK and in vendored typings for them.

Observed on a stock developer machine — scanning `npm root -g`:

```
🚨 HIGH RISK: May 19, 2026 durabletask PyPI compromise indicators detected:
   - /opt/homebrew/lib/node_modules/@google/gemini-cli/node_modules/googleapis/
       build/src/apis/ml/v1.d.ts
     Reason: durabletask C2 reference (/v1/models)

   📋 IMMEDIATE ACTION: … rotate AWS/GCP/Azure/Kubernetes/Vault/GitHub credentials,
                        and audit AWS SSM + kubectl exec history for lateral movement.
```

That's a type-definition file in the Google APIs client. A signal that fires on essentially every developer machine carries no information, and sending a team into credential rotation over it is worse than not having the check.

We hit this while preparing to roll the detector out across our engineering org, which is what surfaced it.

## The fix

The endpoints are now reported only when the same file carries another campaign marker — `check.git-service`, `t.m-kosche`, `rope.pyz`, `pgmonitor`, `pgsql-monitor`, `sys-update-check`, one of the three beacon strings, or `durabletask`.

**Corroboration rather than deletion is deliberate.** Simply dropping the three paths would lose the one case a bare match caught and the C2 host literal does not: a variant that **rotates the C2 domain** while keeping the endpoints. Requiring a marker in the same file keeps that case.

`check.git-service.com`, its defanged form, and `/rope.pyz` are unchanged — those are distinctive enough to stand alone.

### Known residual gap

A rotated C2 host with no other campaign marker anywhere in the same file is no longer reported by this check. I think that's the right trade, but flagging it explicitly rather than burying it: the wave still has five independent signals — the `rope.pyz` SHA-256 in `MALICIOUS_HASHLIST`, the `pgsql-monitor.service` / `pgmonitor.py` / `~/.cache/.sys-update-check*` persistence artifacts, the three beacon strings, the secondary C2 `t.m-kosche.com`, and the pinned `durabletask` versions in `compromised-packages.txt`.

## Tests

Two fixtures, so the false-positive fix cannot silently become a false negative:

| fixture | expectation |
|---|---|
| `durabletask-endpoint-fp/` | benign AI SDK code using `/v1/models`, `/api/public/version`, `/audio.mp3` — **must stay clean** |
| `durabletask-endpoint-corroborated/` | rotated C2 domain + campaign endpoint + campaign marker in one file — **must be HIGH** |

Plus an assertion pinning the *reason* on the corroborated fixture, so it can't start passing on some unrelated finding. Both fixtures are inert — strings only, no payload, no real C2, no network calls.

The two existing IoC assertions were updated to the new finding wording (`durabletask C2 endpoint (…) alongside another campaign marker`). Suite: 238 → 241 checks, `./run-tests.sh` passes 241/241.

## Notes

- Version bumped to 3.15.1. Independent of #158 and #159; whichever lands last needs a trivial CHANGELOG/version rebase, happy to do that whenever you're ready.
- Worth a look at whether other checks carry similarly generic literals — I only audited this one because it's what fired on our machines. I'm happy to do that sweep as a follow-up if useful.

## Sources

Internally found while rolling the detector out. The campaign IoCs themselves are unchanged from the 3.5.0 entry; this only changes the matching conditions for the three endpoint paths.