### PR TITLE
Detect the keyv-wave C2-rotation channel, not just its fallback domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Shai-Hulud NPM Supply Chain Attack Detector will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.0] - 2026-08-05
+
+### Added
+- **C2-rotation channel of the August 4, 2026 keyv/cacheable wave** (`check_keyv_indicators`). The 3.14.1 entry that added `npm-cache[.]com` noted its own weakness: *"the attacker rotates C2 via an Ethereum smart contract without changing the payload, so this specific domain may be short-lived."* The rotation mechanism itself was never matched. It now is:
+  - **Contract `0xE1f2395ee43e45A1556EC6438a88c31B83493103`** — the address the payload reads its current exfil host from. Matched on its own (both the EIP-55 checksummed and all-lowercase forms, since Ethereum addresses are case-insensitive outside checksumming): a 40-hex address has no benign reason to appear in a dependency tree. This is the durable half of the indicator — it survives any number of domain rotations, where `npm-cache[.]com` does not.
+  - **`eth-mainnet.nodereal[.]io`** — the RPC endpoint used to read the contract. **Reported only alongside another wave marker** (the contract address, `npm-cache[.]com`, `Shai-Hulud`, `Math_Symbol`, `math_init`). NodeReal is a legitimate infrastructure provider and this is an ordinary public Ethereum RPC endpoint used by real dapps and wallet tooling; matching it bare would flag benign web3 projects. The disclosed IoC is specifically an `eth-mainnet.nodereal[.]io` request *containing* `0xE1f2395e…`, i.e. the combination, so that is what is matched.
+- **`test-cases/keyv-c2-rotation-attack/`** (HIGH: contract in both cases + corroborated RPC endpoint) and **`test-cases/keyv-c2-rotation-clean/`** (legitimate NodeReal RPC usage — must stay clean), plus four assertions in `run-tests.sh` pinning each IoC and the false-positive guard. Both fixtures are inert string constants. Suite: 238 → 244 checks.
+
+### Changed
+- **`shai-hulud-detector.sh`**: `SCRIPT_VERSION` 3.14.1 → 3.16.0; `check_keyv_indicators`' header rewritten to describe all three network indicators rather than only the fallback domain.
+- **`README.md`**: tests badge/count 238 → 244.
+
 ## [3.14.1] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Shell](https://img.shields.io/badge/shell-Bash%205.0%2B-blue)](#requirements)
 [![Status](https://img.shields.io/badge/status-Active-success)](../../)
-[![Tests](https://img.shields.io/badge/tests-238%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-244%20passing-brightgreen)](#testing)
 [![Packages](https://img.shields.io/badge/compromised%20packages-3%2C460%2B-red)](compromised-packages.txt)
 [![Type](https://img.shields.io/badge/type-Security%20Tool-red)](#what-it-catches)
 [![Contributions](https://img.shields.io/badge/contributions-Welcome-orange)](#contributing)
@@ -253,7 +253,7 @@ To add new packages from a fresh advisory: append entries in that format, run `.
 ## Testing
 
 ```bash
-./run-tests.sh                          # full suite, 238 checks
+./run-tests.sh                          # full suite, 244 checks
 ./shai-hulud-detector.sh test-cases/<fixture-name>   # run one fixture manually
 ```
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -102,6 +102,8 @@ declare -A EXPECTED=(
     ["leoplatform-miasma-clean"]="0|no|no|no"  # Clean: non-compromised (one release below) versions of LeoPlatform/RStreams package names
     ["keyv-shai-hulud-attack"]="1|yes|no|no"   # HIGH: August 4, 2026 Shai-Hulud "Here We Go Again" keyv/cacheable wave (Wiz/Socket) — keyv@6.0.0, flat-cache@6.1.24, file-entry-cache@11.1.6, cacheable-request@13.0.20, @or-sdk/auth@0.38.2; also exercises the extended "node setup.mjs" preinstall pattern
     ["keyv-shai-hulud-clean"]="0|no|no|no"     # Clean: last-known-good versions of keyv/cacheable-wave-targeted package names
+    ["keyv-c2-rotation-attack"]="1|yes|no|no"  # HIGH: Aug 4, 2026 keyv-wave C2-rotation channel (contract 0xE1f2395e… + eth-mainnet.nodereal.io RPC)
+    ["keyv-c2-rotation-clean"]="0|no|no|no"    # Clean: legitimate NodeReal RPC usage — must not fire without another wave marker
     ["go-attack"]="1|yes|no|no"                # HIGH: Go ecosystem support — go.mod + go.sum pin the compromised Verana module (go:github.com/verana-labs/verana-blockchain:v0.10.1-dev.20) from the June 25 Miasma wave
     ["go-clean"]="0|no|no|no"                  # Clean: go.mod requires a non-compromised Verana version (v0.10.0) — exercises the go.mod parser without firing
     ["hex-clean"]="0|no|no|no"                 # Clean: Elixir mix.exs + mix.lock with safe deps — exercises the Hex parsers without firing (no hex: entries in the real list yet). Match path is asserted via the SHAI_HULUD_PACKAGES_FILE override block below.
@@ -467,6 +469,43 @@ do
         ((failed++))
     fi
 done
+
+# ------------------------------------------------------------
+#  keyv/cacheable C2-rotation channel (contract + RPC endpoint)
+# ------------------------------------------------------------
+# The wave rotates its exfil host through an Ethereum contract rather than
+# hard-coding one, so the contract address outlives npm-cache[.]com. The RPC
+# endpoint is only reported alongside another wave marker: NodeReal is a real
+# provider and eth-mainnet.nodereal.io is used by legitimate dapps.
+KEYVROT_OUT=$("$BASH_CMD" "$DETECTOR" "$SCRIPT_DIR/test-cases/keyv-c2-rotation-attack" 2>&1)
+for keyvrot_check in \
+    "C2-rotation contract address (checksummed)|C2-rotation contract address (0xE1f2395ee43e45A1556EC6438a88c31B83493103)" \
+    "C2-rotation contract address (lowercase)|C2-rotation contract address (0xe1f2395ee43e45a1556ec6438a88c31b83493103)" \
+    "C2-rotation RPC endpoint, corroborated|C2-rotation RPC endpoint (eth-mainnet.nodereal.io) alongside another wave marker"
+do
+    label="${keyvrot_check%|*}"
+    pattern="${keyvrot_check#*|}"
+    ((total++))
+    if grep -qF "$pattern" <<< "$KEYVROT_OUT"; then
+        echo -e "${GREEN}PASS${NC}: keyv-c2-rotation-attack fires IoC: $label"
+        ((passed++))
+    else
+        echo -e "${RED}FAIL${NC}: keyv-c2-rotation-attack did NOT fire: $label (looked for: '$pattern')"
+        ((failed++))
+    fi
+done
+
+# The clean fixture is asserted overall by the EXPECTED table; pin the specific
+# regression too, so a future broadening of the RPC match is caught here.
+((total++))
+KEYVROT_CLEAN=$("$BASH_CMD" "$DETECTOR" "$SCRIPT_DIR/test-cases/keyv-c2-rotation-clean" 2>&1)
+if grep -qF "C2-rotation RPC endpoint" <<< "$KEYVROT_CLEAN"; then
+    echo -e "${RED}FAIL${NC}: legitimate NodeReal RPC usage flagged as a keyv-wave C2 indicator"
+    ((failed++))
+else
+    echo -e "${GREEN}PASS${NC}: legitimate NodeReal RPC usage is not flagged without corroboration"
+    ((passed++))
+fi
 
 # ------------------------------------------------------------
 #  Go ecosystem support — go.mod / go.sum parsing + matching

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPROMISED_PACKAGES_FILE="$SCRIPT_DIR/compromised-packages.txt"
 
 # Tool version (surfaced in --json output for downstream consumers)
-SCRIPT_VERSION="3.14.1"
+SCRIPT_VERSION="3.16.0"
 
 # Global temp directory for file-based storage
 TEMP_DIR=""
@@ -2976,15 +2976,20 @@ check_easy_day_js_indicators() {
 }
 
 # Function: check_keyv_indicators
-# Purpose: Detect the fallback C2 / exfil domain of the August 4, 2026 Shai-Hulud
-#          "Here We Go Again" keyv/cacheable wave. The wave's primary exfil is via
-#          GitHub dead-drop repos (caught by the version list, the "node setup.mjs"
-#          preinstall hook, the payload hashes, and the "Shai-Hulud: Here We Go
-#          Again" repo-description marker); this adds the network fallback endpoint
-#          npm-cache[.]com, corroborated by Wiz, Socket (DomainSender), and Aikido.
-#          NOTE: the attacker rotates C2 via an Ethereum smart contract without
-#          changing the payload, so this specific domain may be short-lived — it is
-#          a genuine documented IoC but hash/version detection is the durable signal.
+# Purpose: Detect the network IoCs of the August 4, 2026 Shai-Hulud "Here We Go Again"
+#          keyv/cacheable wave. The wave's primary exfil is via GitHub dead-drop repos
+#          (caught by the version list, the "node setup.mjs" preinstall hook, the
+#          payload hashes, and the "Shai-Hulud: Here We Go Again" repo-description
+#          marker). This covers three network indicators:
+#            1. the fallback exfil domain npm-cache[.]com (Wiz, Socket DomainSender,
+#               Aikido),
+#            2. the C2-rotation contract 0xE1f2395e… , and
+#            3. the eth-mainnet.nodereal[.]io RPC endpoint used to read it, matched
+#               only alongside another wave marker (see IOC 3 for why).
+#          NOTE: the attacker rotates C2 via that Ethereum contract without changing
+#          the payload, so npm-cache[.]com specifically may be short-lived. The
+#          contract address is the more durable network indicator, but hash and
+#          version detection remain the strongest signals for this wave.
 # Args: $1 = scan_dir
 # Modifies: $TEMP_DIR/keyv_indicators.txt
 check_keyv_indicators() {
@@ -3003,6 +3008,50 @@ check_keyv_indicators() {
             fast_grep_files_fixed "$kv_domain" < "$TEMP_DIR/code_files.txt" | \
                 while IFS= read -r file; do
                     echo "$file:keyv/cacheable wave C2 fallback domain ($kv_domain)" >> "$TEMP_DIR/keyv_indicators.txt"
+                done
+        done
+
+        # IOC 2: the C2-rotation channel itself.
+        #
+        # The function header already notes that the attacker rotates C2 through an
+        # Ethereum smart contract without changing the payload, which is what makes
+        # npm-cache[.]com short-lived. The rotation contract is the durable half of
+        # that mechanism, so it is worth matching directly: the payload reads the
+        # current C2 from contract 0xE1f2395ee43e45A1556EC6438a88c31B83493103 over the
+        # eth-mainnet.nodereal[.]io RPC endpoint.
+        #
+        # The address is a 40-hex string with no benign reason to appear in a
+        # dependency tree, so it is matched on its own.
+        local kv_contract
+        for kv_contract in \
+            "0xE1f2395ee43e45A1556EC6438a88c31B83493103" \
+            "0xe1f2395ee43e45a1556ec6438a88c31b83493103"
+        do
+            fast_grep_files_fixed "$kv_contract" < "$TEMP_DIR/code_files.txt" | \
+                while IFS= read -r file; do
+                    echo "$file:keyv/cacheable wave C2-rotation contract address ($kv_contract)" >> "$TEMP_DIR/keyv_indicators.txt"
+                done
+        done
+
+        # IOC 3: the RPC endpoint, reported only alongside another wave marker.
+        #
+        # NodeReal is a legitimate infrastructure provider and eth-mainnet.nodereal.io
+        # is an ordinary public Ethereum RPC endpoint used by real dapps and wallet
+        # tooling. Matching it bare would flag benign web3 projects — the same mistake
+        # that made the durabletask check fire on every AI SDK. The disclosed IoC is
+        # specifically an "eth-mainnet.nodereal[.]io request containing
+        # 0xE1f2395e…", i.e. the combination, so that is what is matched here.
+        local kv_rpc_corroboration='0[xX][eE]1[fF]2395[eE][eE]43[eE]45[aA]1556[eE][cC]6438[aA]88[cC]31[bB]83493103|npm-cache\[?\.\]?com|Shai-Hulud|Math_Symbol|math_init'
+        local kv_rpc
+        for kv_rpc in \
+            "eth-mainnet.nodereal.io" \
+            "eth-mainnet.nodereal[.]io"
+        do
+            fast_grep_files_fixed "$kv_rpc" < "$TEMP_DIR/code_files.txt" | \
+                while IFS= read -r file; do
+                    if fast_grep_quiet "$kv_rpc_corroboration" "$file"; then
+                        echo "$file:keyv/cacheable wave C2-rotation RPC endpoint ($kv_rpc) alongside another wave marker" >> "$TEMP_DIR/keyv_indicators.txt"
+                    fi
                 done
         done
     fi

--- a/test-cases/keyv-c2-rotation-attack/README.md
+++ b/test-cases/keyv-c2-rotation-attack/README.md
@@ -1,0 +1,16 @@
+# keyv-c2-rotation-attack
+
+The C2-rotation channel of the August 4, 2026 Shai-Hulud "Here We Go Again"
+keyv/cacheable wave.
+
+The payload does not hard-code its exfil host. It reads the current C2 from an
+Ethereum smart contract, which is why the fallback domain `npm-cache[.]com`
+is short-lived while the rotation mechanism is not:
+
+- contract `0xE1f2395ee43e45A1556EC6438a88c31B83493103`
+- read over the `eth-mainnet.nodereal[.]io` RPC endpoint
+
+Both are present here, plus the lowercase form of the address, since Ethereum
+addresses are case-insensitive outside EIP-55 checksumming.
+
+Inert: string constants only. No payload, no network calls, no real key.

--- a/test-cases/keyv-c2-rotation-attack/c2_rotation_inert.js
+++ b/test-cases/keyv-c2-rotation-attack/c2_rotation_inert.js
@@ -1,0 +1,4 @@
+// INERT FIXTURE - models the keyv-wave C2 rotation lookup. Nothing executes.
+const RPC = "https://eth-mainnet.nodereal.io/v1/<key>";
+const ROTATION_CONTRACT = "0xE1f2395ee43e45A1556EC6438a88c31B83493103";
+const ROTATION_CONTRACT_LC = "0xe1f2395ee43e45a1556ec6438a88c31b83493103";

--- a/test-cases/keyv-c2-rotation-attack/package.json
+++ b/test-cases/keyv-c2-rotation-attack/package.json
@@ -1,0 +1,1 @@
+{"name":"keyv-c2-rotation-attack","version":"1.0.0"}

--- a/test-cases/keyv-c2-rotation-clean/README.md
+++ b/test-cases/keyv-c2-rotation-clean/README.md
@@ -1,0 +1,11 @@
+# keyv-c2-rotation-clean
+
+False-positive guard for the keyv-wave C2-rotation IoCs.
+
+NodeReal is a legitimate infrastructure provider and `eth-mainnet.nodereal.io`
+is an ordinary public Ethereum RPC endpoint used by real dapps and wallet
+tooling. It must not be flagged on its own — only alongside another wave
+marker. The disclosed IoC is specifically an `eth-mainnet.nodereal[.]io`
+request *containing* the rotation contract address.
+
+This fixture is ordinary web3 client code and must stay clean.

--- a/test-cases/keyv-c2-rotation-clean/package.json
+++ b/test-cases/keyv-c2-rotation-clean/package.json
@@ -1,0 +1,1 @@
+{"name":"keyv-c2-rotation-clean","version":"1.0.0"}

--- a/test-cases/keyv-c2-rotation-clean/provider.js
+++ b/test-cases/keyv-c2-rotation-clean/provider.js
@@ -1,0 +1,7 @@
+// Ordinary web3 client code using a public RPC provider. Nothing malicious.
+const RPC_URL = "https://eth-mainnet.nodereal.io/v1/<key>";
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+export function makeProvider(fetchImpl) {
+  return { url: RPC_URL, token: USDC, fetchImpl };
+}


### PR DESCRIPTION
## Why

The 3.14.1 entry that added `npm-cache[.]com` flagged its own weakness:

> **Caveat:** the attacker rotates C2 via an Ethereum smart contract without changing the payload, so this specific domain may already be dead.

The rotation mechanism itself was never matched. Once the domain rotates, `check_keyv_indicators` has nothing left to find. This adds both halves of that mechanism.

## What's added

**Contract `0xE1f2395ee43e45A1556EC6438a88c31B83493103`** — the address the payload reads its current exfil host from. Matched on its own, in both the EIP-55 checksummed and all-lowercase forms (Ethereum addresses are case-insensitive outside checksumming). A 40-hex address has no benign reason to appear in a dependency tree.

This is the durable half of the indicator: it survives any number of domain rotations, where `npm-cache[.]com` does not.

**`eth-mainnet.nodereal[.]io`** — the RPC endpoint used to read the contract. **Reported only alongside another wave marker** (the contract address, `npm-cache[.]com`, `Shai-Hulud`, `Math_Symbol`, `math_init`).

NodeReal is a legitimate infrastructure provider and this is an ordinary public Ethereum RPC endpoint used by real dapps and wallet tooling. Matching it bare would flag benign web3 projects. The disclosed IoC is specifically an `eth-mainnet.nodereal[.]io` request *containing* `0xE1f2395e…` — the combination — so that's what's matched.

## Tests

| fixture | expectation |
|---|---|
| `keyv-c2-rotation-attack/` | contract in both cases + corroborated RPC endpoint — **HIGH** |
| `keyv-c2-rotation-clean/` | legitimate NodeReal RPC usage — **must stay clean** |

Four assertions pin each IoC individually plus the false-positive guard, so a future broadening of the RPC match gets caught. Both fixtures are inert string constants — no payload, no network calls, no real API key.

Suite: 238 → 244 checks, `./run-tests.sh` passes 244/244.

## Notes

- Version bumped to 3.16.0 as new detection coverage. Independent of #158, #159 and #160; whichever lands last needs a trivial CHANGELOG/version rebase, happy to do that on request.
- The corroboration approach here is the same one used in #160, for the same reason — a network indicator that also appears in legitimate code is only useful in combination.

## Sources

- Aikido — [keyv and friends compromised in npm supply chain attack](https://www.aikido.dev/blog/keyv-and-friends-compromised-in-npm-supply-chain-attack)
- BleepingComputer — [Massive ChainDrop npm supply chain attack infects hundreds of packages](https://www.bleepingcomputer.com/news/security/massive-chaindrop-npm-supply-chain-attack-infects-hundreds-of-packages/)

Both IoCs are listed in those disclosures alongside the `npm-cache[.]com:443/router` endpoint already covered in 3.14.1, and the three payload hashes already in `MALICIOUS_HASHLIST`.