### PR TITLE
Detect installed packages by identity, not only as declared dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Shai-Hulud NPM Supply Chain Attack Detector will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.18.0] - 2026-08-05
+
+### Fixed
+- **A compromised package sitting on disk was invisible unless something declared it as a dependency.** `check_packages` extracted only `dependencies` / `devDependencies` blocks, so a `package.json`'s own `name` + `version` was never matched against the compromised list. `npm i -g keyv@6.0.0` produced `✅ No indicators of Shai-Hulud compromise detected` — the payload was installed, but no manifest pointed at it. The same blind spot covers any `node_modules` tree whose lockfile is absent, stale, or was regenerated after the fact.
+  - This mattered most for the one directory people scan deliberately: `$(npm root -g)` is *nothing but* installed packages with no parent manifest, so the check that should catch a compromised global CLI was the check that could not run.
+  - Manifests now contribute their own identity to the dependency set. Only the top-level `name`/`version` are used — nesting depth is tracked so a dependency literally called `name` or `version` cannot be mistaken for the manifest's own.
+- **An ecosystem whose only markers live in an excluded directory is now detected.** `ECOSYSTEM_EXCLUDE_PATHS[npm]="node_modules"` stops vendored dependencies from activating npm for a project that does not use it — sensible when the project has manifests elsewhere. But when the *only* markers in the tree are inside the excluded directory, the exclusion removed the entire basis for detection and every npm check was skipped. Again this is precisely `$(npm root -g)`: users had to know to pass `--ecosystem npm`, and without it got a green result that meant nothing. Detection now falls back to the excluded paths when they are all there is. Projects with their own manifests are unaffected — the fallback only fires when the first pass finds nothing.
+
+### Added
+- **`test-cases/global-install-attack/`** (HIGH: a compromised package with no declaring manifest) and **`test-cases/global-install-clean/`** (same shape, last-known-good version — the identity match must not fire on the package name alone). Neither has a top-level `package.json`, so they also exercise the ecosystem-detection fallback. Plus assertions for the identity match and for npm activating on a `node_modules`-only root. Suite: 238 → 242 checks.
+
+### Changed
+- **`shai-hulud-detector.sh`**: `SCRIPT_VERSION` 3.14.1 → 3.18.0.
+- **`README.md`**: tests badge/count 238 → 242.
+
 ## [3.14.1] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Shell](https://img.shields.io/badge/shell-Bash%205.0%2B-blue)](#requirements)
 [![Status](https://img.shields.io/badge/status-Active-success)](../../)
-[![Tests](https://img.shields.io/badge/tests-238%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-242%20passing-brightgreen)](#testing)
 [![Packages](https://img.shields.io/badge/compromised%20packages-3%2C460%2B-red)](compromised-packages.txt)
 [![Type](https://img.shields.io/badge/type-Security%20Tool-red)](#what-it-catches)
 [![Contributions](https://img.shields.io/badge/contributions-Welcome-orange)](#contributing)
@@ -253,7 +253,7 @@ To add new packages from a fresh advisory: append entries in that format, run `.
 ## Testing
 
 ```bash
-./run-tests.sh                          # full suite, 238 checks
+./run-tests.sh                          # full suite, 242 checks
 ./shai-hulud-detector.sh test-cases/<fixture-name>   # run one fixture manually
 ```
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -48,6 +48,8 @@ declare -A EXPECTED=(
     ["false-positive-project"]="2|no|yes|no"   # MEDIUM: potential false positives
     ["github-actions-runners"]="1|yes|no|no"   # HIGH: malicious runners
     ["gitlab-false-positive"]="0|no|no|no"    # Clean: non-.github YAML files (issue #83)
+    ["global-install-attack"]="1|yes|no|no"  # HIGH: compromised package present on disk with nothing declaring it (global install / stale lockfile shape)
+    ["global-install-clean"]="0|no|no|no"     # Clean: same shape, last-known-good version — identity match must not fire on the name alone
     ["hash-verification"]="1|yes|no|no"        # HIGH: known malicious hashes (was timeout in orig)
     ["infected-lockfile"]="2|no|yes|no"        # MEDIUM: lockfile issues
     ["infected-lockfile-pnpm"]="2|no|yes|no"   # MEDIUM: pnpm lockfile issues
@@ -646,6 +648,37 @@ for helper in fast_grep_files fast_grep_files_i fast_grep_files_fixed; do
     fi
 done
 rm -rf "$XARGS_TMP"
+
+# ============================================================
+#  Installed-package identity (global installs, stale lockfiles)
+# ============================================================
+# check_packages only ever read dependencies / devDependencies blocks, so a manifest's
+# own name+version was never matched. A package sitting on disk that nothing declares
+# — `npm i -g <compromised>`, or a node_modules tree whose lockfile is gone — was
+# invisible. That is the exact shape of $(npm root -g), i.e. the directory people scan
+# to check their globally installed CLIs.
+#
+# Both fixtures deliberately have NO top-level package.json, which is also what makes
+# them exercise the ecosystem-detection fallback: npm markers exist only inside
+# node_modules, and the npm exclusion used to remove the entire basis for detection.
+((total++))
+GLOBID_OUT=$("$BASH_CMD" "$DETECTOR" "$SCRIPT_DIR/test-cases/global-install-attack" 2>&1)
+if grep -qF "keyv@6.0.0" <<< "$GLOBID_OUT"; then
+    echo -e "${GREEN}PASS${NC}: installed package matched by its own identity (no declaring manifest)"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: installed package not matched by identity - a global install would be missed"
+    ((failed++))
+fi
+
+((total++))
+if grep -qF "Detected ecosystems: npm" <<< "$GLOBID_OUT"; then
+    echo -e "${GREEN}PASS${NC}: npm activates when its only markers are inside node_modules"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: npm not activated for a node_modules-only root (needs --ecosystem npm)"
+    ((failed++))
+fi
 
 # ============================================================
 #  Paranoid-mode confusable-substring regression

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPROMISED_PACKAGES_FILE="$SCRIPT_DIR/compromised-packages.txt"
 
 # Tool version (surfaced in --json output for downstream consumers)
-SCRIPT_VERSION="3.14.1"
+SCRIPT_VERSION="3.18.0"
 
 # Global temp directory for file-based storage
 TEMP_DIR=""
@@ -413,6 +413,24 @@ detect_ecosystems() {
         # paths that contain ecosystem-irrelevant directories.
         if grep -E "/($markers)$" "$TEMP_DIR/all_files_raw.txt" 2>/dev/null | \
            grep -vE "/($exclude)/" 2>/dev/null | head -n1 | grep -q .; then
+            ACTIVE_ECOSYSTEMS+=("$eco")
+            continue
+        fi
+
+        # Fall back to the excluded paths when they are ALL there is.
+        #
+        # The exclusions exist so that vendored dependencies do not activate an
+        # ecosystem the project does not actually use — reasonable when the project
+        # has its own manifests elsewhere. But when the ONLY markers in the tree are
+        # inside the excluded directories, the exclusion removes the entire basis for
+        # detection and the ecosystem's checks never run at all.
+        #
+        # That is exactly the shape of a global package root: `$(npm root -g)` is
+        # nothing but `node_modules/`, so scanning the directory that holds every
+        # globally installed CLI silently skipped the npm package check and reported
+        # clean. Users had to know to pass --ecosystem npm to get any result.
+        if [[ -n "$exclude" ]] && \
+           grep -E "/($markers)$" "$TEMP_DIR/all_files_raw.txt" 2>/dev/null | head -n1 | grep -q .; then
             ACTIVE_ECOSYSTEMS+=("$eco")
         fi
     done
@@ -3898,8 +3916,38 @@ check_packages() {
                 gsub(/,/, "\n", buf)
                 n = split(buf, lines, "\n")
                 flag = 0
+                depth = 0
+                self_name = ""
+                self_ver = ""
                 for (i = 1; i <= n; i++) {
                     line = lines[i]
+
+                    # Track object nesting. The explode step above guarantees each
+                    # brace sits alone on its line, so this is exact. Used only by the
+                    # self-identity capture below; the dependency logic is unchanged.
+                    if (line ~ /^[[:space:]]*\{[[:space:]]*$/) { depth++ }
+                    else if (line ~ /^[[:space:]]*\}[[:space:]]*$/) { depth-- }
+
+                    # A manifest also identifies ITS OWN package. Capture the top-level
+                    # (depth 1) name/version so an installed package is matched by
+                    # identity, not only when some parent manifest happens to list it
+                    # as a dependency. Without this, `npm i -g <compromised>` and any
+                    # node_modules tree whose lockfile is absent or stale went
+                    # undetected: the payload was on disk, but nothing declared it.
+                    # Checked before the dependency block because that block "continue"s.
+                    if (depth == 1 && line ~ /^[[:space:]]*"name"[[:space:]]*:[[:space:]]*"/) {
+                        v = line
+                        sub(/^[[:space:]]*"name"[[:space:]]*:[[:space:]]*"/, "", v)
+                        sub(/".*$/, "", v)
+                        if (length(v) > 0) self_name = v
+                    }
+                    if (depth == 1 && line ~ /^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"/) {
+                        v = line
+                        sub(/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"/, "", v)
+                        sub(/".*$/, "", v)
+                        if (length(v) > 0) self_ver = v
+                    }
+
                     # Only the dependencies / devDependencies objects (match original scope).
                     if (line ~ /"(dependencies|devDependencies)"[[:space:]]*:/) { flag = 1; continue }
                     if (line ~ /^[[:space:]]*\}/) { flag = 0; continue }
@@ -3909,6 +3957,7 @@ check_packages() {
                         if (length(name) > 0 && length(ver) > 0) print FILENAME "|" name ":" ver
                     }
                 }
+                if (self_name != "" && self_ver != "") print FILENAME "|" self_name ":" self_ver
             }
         ' > "$TEMP_DIR/all_deps.txt" 2>/dev/null
 

--- a/test-cases/global-install-attack/README.md
+++ b/test-cases/global-install-attack/README.md
@@ -1,0 +1,13 @@
+# global-install-attack
+
+A compromised package present on disk with **nothing declaring it as a dependency** —
+the shape of a global install (`npm i -g keyv@6.0.0`, i.e. `$(npm root -g)`), and
+equally of a `node_modules` tree whose lockfile is absent or stale.
+
+`check_packages` only ever read `dependencies` / `devDependencies` blocks, so a
+manifest's own `name` + `version` was never matched. The payload sat on disk and
+nothing pointed at it, so the scan reported clean. This matters most for exactly
+the directory people scan to check their globally installed CLIs.
+
+No top-level `package.json` here on purpose: that is what a global root looks like.
+Inert — a name and a version string, nothing else.

--- a/test-cases/global-install-attack/node_modules/keyv/package.json
+++ b/test-cases/global-install-attack/node_modules/keyv/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "keyv",
+  "version": "6.0.0",
+  "description": "INERT FIXTURE - identity only, no code"
+}

--- a/test-cases/global-install-clean/README.md
+++ b/test-cases/global-install-clean/README.md
@@ -1,0 +1,4 @@
+# global-install-clean
+
+Same shape as `global-install-attack`, but a last-known-good version. Guards the
+identity match against firing on the package *name* alone.

--- a/test-cases/global-install-clean/node_modules/keyv/package.json
+++ b/test-cases/global-install-clean/node_modules/keyv/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "keyv",
+  "version": "5.3.4",
+  "description": "INERT FIXTURE - identity only, no code"
+}


### PR DESCRIPTION
## The gap

`check_packages` extracts only `dependencies` / `devDependencies` blocks, so a `package.json`'s own `name` + `version` was never matched against the compromised list. A compromised package sitting on disk with nothing declaring it was invisible:

```
$ npm i -g keyv@6.0.0
$ ./shai-hulud-detector.sh "$(npm root -g)"
✅ No indicators of Shai-Hulud compromise detected.
```

The payload is installed. No manifest points at it, so nothing matches. The same blind spot covers any `node_modules` tree whose lockfile is absent, stale, or regenerated after the fact.

This matters most for the one directory people scan deliberately. `$(npm root -g)` is *nothing but* installed packages with no parent manifest — so the check that should catch a compromised global CLI was exactly the check that couldn't run.

Manifests now contribute their own identity to the dependency set, flowing through the existing `comm` intersection and reporting unchanged. Only the top-level `name`/`version` are used: object nesting depth is tracked, so a dependency literally called `name` or `version` can't be mistaken for the manifest's own.

## A second gate in the same path

`ECOSYSTEM_EXCLUDE_PATHS[npm]="node_modules"` stops vendored dependencies from activating npm for a project that doesn't use it — sensible when the project has manifests elsewhere. But when the *only* markers in the tree are inside the excluded directory, the exclusion removes the entire basis for detection and every npm check is skipped:

```
$ ./shai-hulud-detector.sh "$(npm root -g)"
   No package-manifest markers detected.
✅ No indicators …                       # package check never ran

$ ./shai-hulud-detector.sh --ecosystem npm "$(npm root -g)"
🚨 HIGH RISK: flat-cache@6.1.24
```

Users had to know to pass `--ecosystem npm`, and without it got a green result that meant nothing. Detection now falls back to the excluded paths when they're all there is. Projects with their own manifests are unaffected — the fallback only fires when the first pass finds nothing.

Both fixes are needed for the same real scenario; either alone still leaves `$(npm root -g)` reporting clean.

## Tests

| fixture | expectation |
|---|---|
| `global-install-attack/` | compromised package, nothing declares it — **HIGH** |
| `global-install-clean/` | same shape, last-known-good version — **must stay clean** |

The clean fixture is the guard that matters: it fails if the identity match ever fires on the package *name* alone. Neither fixture has a top-level `package.json`, which is both what a global root actually looks like and what exercises the ecosystem fallback. Contents are a name and a version string — nothing executable.

Plus assertions for the identity match and for npm activating on a `node_modules`-only root. Suite: 238 → 242 checks, `./run-tests.sh` passes 242/242. I ran the identity change alone against the existing suite first (238/238) to confirm no fixture's own manifest starts matching.

## Notes

- Version bumped to 3.18.0. Independent of #158/#159/#160/#161/#162; whichever lands last needs a trivial CHANGELOG/version rebase.
- Possible behaviour change worth calling out: a project whose *own* `name`+`version` matches a compromised entry will now be flagged. That seems right — it means you're sitting on that exact published version — but it's a new class of finding.

## Sources

Internally found while rolling the detector out across our engineering org. This is the gap that made a global-package scan look clean on a machine that had the packages installed.