### PR TITLE
Resolve symlinked scan roots instead of silently scanning nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the Shai-Hulud NPM Supply Chain Attack Detector will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.19.0] - 2026-08-05
+
+### Fixed
+- **A symlinked scan root scanned nothing and reported clean.** `find` does not descend a start path that is itself a symlink, and both `main()` and `run_bulk_scan` normalised paths with the default **logical** `pwd`, which preserves the symlink. The result was the worst failure mode this tool has: a full pass, exit 0, `✅ No indicators of Shai-Hulud compromise detected` — for a tree that was never opened.
+  - Measured on a real machine where `/work` is a symlink to `/Volumes/Work`: `--bulk --bulk-list /work` reported **`No projects found under: /work — nothing to do`**. After the fix the same command discovers **698 projects**. A plain scan of a path under `/work` likewise collected zero files.
+  - Passing a trailing slash (`/work/`) does make `find` resolve the link, but the logical `pwd` strips it again, so that workaround failed identically — there was no way to scan such a root correctly.
+  - Symlinked roots are ordinary, not exotic: `/work -> /Volumes/Work` and `/opt/<x> -> …` in corporate layouts, macOS's own `/tmp -> /private/tmp`, and anything bind-mount-shaped. `pwd -P` is now used at all three normalisation sites, so `find`, `GREP_BASE` and the reports all see a real path.
+- **`--bulk-output` inside a scan root was scanned as a project again.** `_bulk_resolve_abs` did not resolve symlinks, so once discovery returned physical paths the two could no longer be compared — on macOS `mktemp -d` yields `/var/folders/…` while the physical path is `/private/var/folders/…`. It now resolves the deepest existing ancestor, since the output directory usually does not exist yet. Caught by the existing hardening test from 3.2.1.
+
+### Added
+- **Two assertions** covering a symlinked root for both a plain scan and `--bulk` discovery, using an inert generated fixture. Both fail on the unpatched code. Suite: 238 → 240 checks.
+
+### Changed
+- **`shai-hulud-detector.sh`**: `SCRIPT_VERSION` 3.14.1 → 3.19.0. Scan targets and bulk roots are reported as their resolved physical paths.
+- **`README.md`**: tests badge/count 238 → 240.
+
 ## [3.14.1] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Shell](https://img.shields.io/badge/shell-Bash%205.0%2B-blue)](#requirements)
 [![Status](https://img.shields.io/badge/status-Active-success)](../../)
-[![Tests](https://img.shields.io/badge/tests-238%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-240%20passing-brightgreen)](#testing)
 [![Packages](https://img.shields.io/badge/compromised%20packages-3%2C460%2B-red)](compromised-packages.txt)
 [![Type](https://img.shields.io/badge/type-Security%20Tool-red)](#what-it-catches)
 [![Contributions](https://img.shields.io/badge/contributions-Welcome-orange)](#contributing)
@@ -253,7 +253,7 @@ To add new packages from a fresh advisory: append entries in that format, run `.
 ## Testing
 
 ```bash
-./run-tests.sh                          # full suite, 238 checks
+./run-tests.sh                          # full suite, 240 checks
 ./shai-hulud-detector.sh test-cases/<fixture-name>   # run one fixture manually
 ```
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -648,6 +648,44 @@ done
 rm -rf "$XARGS_TMP"
 
 # ============================================================
+#  Symlinked scan root must be resolved, not scanned as a symlink
+# ============================================================
+# `find` does not descend a start path that is itself a symlink, and main() used the
+# default LOGICAL `pwd`, which preserves the symlink. Scanning /work (a symlink to
+# /Volumes/Work) collected zero files and printed "No indicators of Shai-Hulud
+# compromise detected" — a clean bill of health for a tree that was never opened.
+# --bulk was hit the same way: "No projects found". A trailing slash makes `find`
+# resolve the link, but the logical `pwd` strips it, so `/work/` failed identically.
+# Symlinked roots are ordinary: /work -> /Volumes/Work, macOS /tmp -> /private/tmp.
+SYMROOT_TMP=$(mktemp -d)
+mkdir -p "$SYMROOT_TMP/real/proj"
+# Inert: a compromised version string in a manifest, nothing executable.
+printf '{"name":"p","version":"1.0.0","dependencies":{"keyv":"6.0.0"}}\n' \
+    > "$SYMROOT_TMP/real/proj/package.json"
+ln -s "$SYMROOT_TMP/real" "$SYMROOT_TMP/link"
+
+((total++))
+SYMROOT_OUT=$("$BASH_CMD" "$DETECTOR" "$SYMROOT_TMP/link" 2>&1)
+if grep -qF "keyv@6.0.0" <<< "$SYMROOT_OUT"; then
+    echo -e "${GREEN}PASS${NC}: symlinked scan root is resolved (plain scan)"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: symlinked scan root scanned nothing and reported clean (plain scan)"
+    ((failed++))
+fi
+
+((total++))
+SYMROOT_BULK=$("$BASH_CMD" "$DETECTOR" --bulk --bulk-list "$SYMROOT_TMP/link" 2>&1)
+if grep -q "/proj$" <<< "$SYMROOT_BULK"; then
+    echo -e "${GREEN}PASS${NC}: symlinked scan root is resolved (--bulk discovery)"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: --bulk found no projects under a symlinked root"
+    ((failed++))
+fi
+rm -rf "$SYMROOT_TMP"
+
+# ============================================================
 #  Paranoid-mode confusable-substring regression
 # ============================================================
 # Lock in the fix for the bare-substring false positive (yarn/intern/return/modern

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPROMISED_PACKAGES_FILE="$SCRIPT_DIR/compromised-packages.txt"
 
 # Tool version (surfaced in --json output for downstream consumers)
-SCRIPT_VERSION="3.14.1"
+SCRIPT_VERSION="3.19.0"
 
 # Global temp directory for file-based storage
 TEMP_DIR=""
@@ -6228,11 +6228,23 @@ _bulk_is_in_output_dir() {
 _bulk_resolve_abs() {
     local p="$1"
     [[ -z "$p" ]] && return 0
-    if [[ "$p" == /* ]]; then
-        printf '%s\n' "$p"
-    else
-        printf '%s/%s\n' "$PWD" "$p"
-    fi
+    [[ "$p" == /* ]] || p="$PWD/$p"
+
+    # Resolve symlinks, so this is comparable with discovery output — which uses
+    # `pwd -P`. Without this the output directory is not recognised as being inside a
+    # scan root and gets scanned as if it were a project: on macOS `mktemp -d` hands
+    # back /var/folders/… while the physical path is /private/var/folders/…, so the
+    # string comparison never matched.
+    #
+    # The directory usually does not exist yet, so resolve the deepest existing
+    # ancestor and re-append the part that does not exist.
+    local head="$p" tail=""
+    while [[ "$head" != "/" && -n "$head" && ! -d "$head" ]]; do
+        tail="$(basename "$head")${tail:+/$tail}"
+        head="$(dirname "$head")"
+    done
+    [[ -d "$head" ]] && head="$(cd "$head" && pwd -P)"
+    printf '%s\n' "${head%/}${tail:+/$tail}"
 }
 
 # Function: _bulk_collect_unreadable
@@ -6624,7 +6636,7 @@ run_bulk_scan() {
             print_status "$YELLOW" "⚠️  Skipping parent '$root' — not a directory."
             continue
         fi
-        root="$(cd "$root" && pwd)"
+        root="$(cd "$root" && pwd -P)"   # -P: resolve symlinks, see main()
         local _child_orig
         while IFS= read -r child; do
             [[ -d "$child" ]] || continue                       # follows symlinks; drops broken links
@@ -6722,7 +6734,7 @@ run_bulk_scan() {
     local resolved_roots="" r
     for r in "${roots[@]}"; do
         [[ -d "$r" ]] || continue
-        resolved_roots+="${resolved_roots:+, }$(cd "$r" && pwd)"
+        resolved_roots+="${resolved_roots:+, }$(cd "$r" && pwd -P)"
     done
 
     print_status "$GREEN" "Bulk scan: ${#targets[@]} project director$([[ ${#targets[@]} -eq 1 ]] && echo "y" || echo "ies") to process."
@@ -7012,8 +7024,19 @@ main() {
         exit 1
     fi
 
-    # Convert to absolute path
-    if ! scan_dir=$(cd "$scan_dir" && pwd); then
+    # Convert to an absolute, symlink-resolved path.
+    #
+    # `pwd -P` (physical), not the default logical `pwd`: `find` does not descend into
+    # a start path that is itself a symlink, and the logical form preserves the
+    # symlink. Scanning `/work` (a symlink to `/Volumes/Work`) collected ZERO files and
+    # reported "No indicators of Shai-Hulud compromise detected" — a clean bill of
+    # health for a tree that was never opened. A trailing slash happens to make `find`
+    # resolve it, but the logical `pwd` strips that too, so `/work/` failed identically.
+    #
+    # Symlinked scan roots are ordinary: /work -> /Volumes/Work, /opt/<x> -> elsewhere,
+    # macOS /tmp -> /private/tmp, and any bind-mount-style layout. Resolving here means
+    # every downstream consumer (find, GREP_BASE, the reports) sees a real path.
+    if ! scan_dir=$(cd "$scan_dir" && pwd -P); then
         print_status "$RED" "Error: Unable to access directory '$scan_dir' or convert to absolute path."
         exit 1
     fi


### PR DESCRIPTION
## The bug

`find` does not descend a start path that is itself a symlink. Both `main()` and `run_bulk_scan` normalised paths with the default **logical** `pwd`, which preserves the symlink:

```bash
scan_dir=$(cd "$scan_dir" && pwd)      # /work stays /work
root="$(cd "$root" && pwd)"
```

The result is the worst failure this tool can produce — a full pass, exit 0, and:

```
✅ No indicators of Shai-Hulud compromise detected.
```

…for a tree that was never opened.

Measured on a machine where `/work` is a symlink to `/Volumes/Work`:

```
$ ./shai-hulud-detector.sh --bulk --bulk-list /work
No projects found under: /work — nothing to do.

$ # after the fix
698 projects discovered
```

A plain scan of a path under `/work` likewise collected zero files. Passing a trailing slash (`/work/`) *does* make `find` resolve the link — but the logical `pwd` strips it again, so that failed identically. There was no way to scan such a root correctly.

Symlinked roots are ordinary rather than exotic: `/work -> /Volumes/Work` and `/opt/<x> -> …` in corporate layouts, macOS's own `/tmp -> /private/tmp`, and anything bind-mount-shaped.

## The fix

`pwd -P` at all three normalisation sites, so `find`, `GREP_BASE` and the reports all see a real path. Scan targets and bulk roots are consequently reported as their resolved physical paths.

`_bulk_resolve_abs` needed the same treatment, and this is worth a close look since it's the non-obvious half. Once discovery returns physical paths, an unresolved `--bulk-output` path can no longer be compared against them — on macOS `mktemp -d` yields `/var/folders/…` while the physical path is `/private/var/folders/…` — so an output directory inside a scan root was scanned as a project again. It now resolves the deepest *existing* ancestor and re-appends the rest, because the output directory usually doesn't exist yet.

I caught that regression only because the hardening test added in 3.2.1 failed. Worth noting as evidence that test earns its keep.

## Tests

Two assertions covering a symlinked root for both a plain scan and `--bulk` discovery, using an inert generated fixture (a manifest with a compromised version string, nothing executable). Both fail on unpatched code.

Suite: 238 → 240 checks, `./run-tests.sh` passes 240/240.

## Notes

- Version bumped to 3.19.0. Independent of #158–#163; whichever lands last needs a trivial CHANGELOG/version rebase.
- One user-visible change: paths in output are now the resolved physical form. `/work/foo` is reported as `/Volumes/Work/foo`. That seemed right — it's unambiguous, and it's what was actually scanned — but say the word if you'd rather preserve the path as given.

## Sources

Internally found while rehearsing a company-wide rollout; `/work` being a symlink is what surfaced it.