### PR TITLE
Keep trufflehog findings at their own severity in --save-log and --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Shai-Hulud NPM Supply Chain Attack Detector will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.0] - 2026-08-05
+
+### Fixed
+- **`--bulk` rows could contradict themselves, e.g. `🟡 MEDIUM RISK (H:4 M:0 L:0)`.** `trufflehog_activity.txt` stores entries as `path:SEVERITY:message` and mixes HIGH, MEDIUM and LOW in one file, but the `--save-log` and `--json` writers dumped the **whole file** into the HIGH bucket via `cut -d: -f1`, discarding the severity field. A file that merely mentions trufflehog is a MEDIUM finding (`Contains trufflehog references in source code`), so it was recorded as HIGH.
+  - In `--bulk` the row label comes from the child's exit code (correctly MEDIUM, since only `medium_risk` was incremented) while the H/M/L counts are parsed from the saved log (wrongly HIGH) — producing rows that contradict themselves and invite mis-triage in both directions.
+  - **`--json` was affected identically**, marking every trufflehog finding HIGH. That matters more, since it is the machine-readable output downstream tooling is meant to build on.
+  - Each severity is now emitted into its own section, matching what the neighbouring `crypto_patterns.txt` writer already did (`grep -E "(HIGH RISK|Known attacker wallet)"`). The `--json` message no longer carries a redundant `HIGH:` / `MEDIUM:` prefix.
+
+### Added
+- **Two assertions** pinning trufflehog severity in `--save-log` and in `--json`, using an inert fixture whose only marker is a bare reference to the tool name. Both fail on the unpatched code. The `--json` one skips when `jq` is absent, matching the existing convention. Suite: 238 → 241 checks.
+
+### Changed
+- **`shai-hulud-detector.sh`**: `SCRIPT_VERSION` 3.14.1 → 3.20.0.
+- **`README.md`**: tests badge/count 238 → 241.
+
 ## [3.14.1] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Shell](https://img.shields.io/badge/shell-Bash%205.0%2B-blue)](#requirements)
 [![Status](https://img.shields.io/badge/status-Active-success)](../../)
-[![Tests](https://img.shields.io/badge/tests-238%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-241%20passing-brightgreen)](#testing)
 [![Packages](https://img.shields.io/badge/compromised%20packages-3%2C460%2B-red)](compromised-packages.txt)
 [![Type](https://img.shields.io/badge/type-Security%20Tool-red)](#what-it-catches)
 [![Contributions](https://img.shields.io/badge/contributions-Welcome-orange)](#contributing)
@@ -253,7 +253,7 @@ To add new packages from a fresh advisory: append entries in that format, run `.
 ## Testing
 
 ```bash
-./run-tests.sh                          # full suite, 238 checks
+./run-tests.sh                          # full suite, 241 checks
 ./shai-hulud-detector.sh test-cases/<fixture-name>   # run one fixture manually
 ```
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -48,6 +48,7 @@ declare -A EXPECTED=(
     ["false-positive-project"]="2|no|yes|no"   # MEDIUM: potential false positives
     ["github-actions-runners"]="1|yes|no|no"   # HIGH: malicious runners
     ["gitlab-false-positive"]="0|no|no|no"    # Clean: non-.github YAML files (issue #83)
+    ["secret-scanner-mention"]="2|no|yes|no"  # MEDIUM: bare trufflehog reference - pins severity attribution in --save-log/--json
     ["hash-verification"]="1|yes|no|no"        # HIGH: known malicious hashes (was timeout in orig)
     ["infected-lockfile"]="2|no|yes|no"        # MEDIUM: lockfile issues
     ["infected-lockfile-pnpm"]="2|no|yes|no"   # MEDIUM: pnpm lockfile issues
@@ -646,6 +647,46 @@ for helper in fast_grep_files fast_grep_files_i fast_grep_files_fixed; do
     fi
 done
 rm -rf "$XARGS_TMP"
+
+# ============================================================
+#  trufflehog findings must keep their own severity in --save-log / --json
+# ============================================================
+# trufflehog_activity.txt stores "path:SEVERITY:message" and mixes HIGH/MEDIUM/LOW.
+# The --save-log and --json writers dumped the WHOLE file as HIGH, so a file that
+# merely mentions trufflehog (a MEDIUM finding) was recorded as HIGH. Under --bulk this
+# produced self-contradicting rows: "MEDIUM RISK (H:4 M:0 L:0)" - the label comes from
+# the child exit code (correctly MEDIUM), the counts from the log (wrongly HIGH).
+TH_FIX="$SCRIPT_DIR/test-cases/secret-scanner-mention"
+TH_LOG=$(mktemp)
+
+((total++))
+"$BASH_CMD" "$DETECTOR" --save-log "$TH_LOG" "$TH_FIX" >/dev/null 2>&1
+TH_HIGH=$(awk '$0=="# HIGH"{s=1;next} /^# /{s=0} s&&length($0)>0{c++} END{print c+0}' "$TH_LOG")
+TH_MED=$(awk '$0=="# MEDIUM"{s=1;next} /^# /{s=0} s&&length($0)>0{c++} END{print c+0}' "$TH_LOG")
+if [[ "$TH_HIGH" -eq 0 && "$TH_MED" -ge 1 ]]; then
+    echo -e "${GREEN}PASS${NC}: MEDIUM trufflehog finding is logged as MEDIUM, not HIGH"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: trufflehog severity mis-graded in --save-log (HIGH=$TH_HIGH MEDIUM=$TH_MED)"
+    ((failed++))
+fi
+rm -f "$TH_LOG"
+
+if command -v jq >/dev/null 2>&1; then
+    ((total++))
+    TH_JSON=$(mktemp)
+    "$BASH_CMD" "$DETECTOR" --json "$TH_JSON" "$TH_FIX" >/dev/null 2>&1
+    if [[ "$(jq -r '[.findings[]|select(.message|test("trufflehog"))|.severity]|unique|join(",")' "$TH_JSON" 2>/dev/null)" == "MEDIUM" ]]; then
+        echo -e "${GREEN}PASS${NC}: MEDIUM trufflehog finding is MEDIUM in --json too"
+        ((passed++))
+    else
+        echo -e "${RED}FAIL${NC}: trufflehog severity mis-graded in --json"
+        ((failed++))
+    fi
+    rm -f "$TH_JSON"
+else
+    echo -e "${YELLOW}SKIP${NC}: trufflehog --json severity (jq not installed)"
+fi
 
 # ============================================================
 #  Paranoid-mode confusable-substring regression

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPROMISED_PACKAGES_FILE="$SCRIPT_DIR/compromised-packages.txt"
 
 # Tool version (surfaced in --json output for downstream consumers)
-SCRIPT_VERSION="3.14.1"
+SCRIPT_VERSION="3.20.0"
 
 # Global temp directory for file-based storage
 TEMP_DIR=""
@@ -5041,7 +5041,7 @@ write_log_file() {
         [[ -s "$TEMP_DIR/compromised_found.txt" ]] && cut -d: -f1 "$TEMP_DIR/compromised_found.txt" || true
 
         # Trufflehog activity (extract file path before colon)
-        [[ -s "$TEMP_DIR/trufflehog_activity.txt" ]] && cut -d: -f1 "$TEMP_DIR/trufflehog_activity.txt" || true
+        _trufflehog_by_severity HIGH || true
 
         # Shai-Hulud repos
         [[ -s "$TEMP_DIR/shai_hulud_repos.txt" ]] && cat "$TEMP_DIR/shai_hulud_repos.txt" || true
@@ -5055,6 +5055,8 @@ write_log_file() {
     # MEDIUM RISK files
     echo "# MEDIUM" >> "$log_file"
     {
+        # Trufflehog rows graded MEDIUM (see _trufflehog_by_severity)
+        _trufflehog_by_severity MEDIUM || true
         # Suspicious packages (extract file path)
         # Note: Using || true to prevent pipefail from causing non-zero exit on empty files
         [[ -s "$TEMP_DIR/suspicious_found.txt" ]] && cut -d: -f1 "$TEMP_DIR/suspicious_found.txt" || true
@@ -5101,6 +5103,8 @@ write_log_file() {
 
         # Namespace warnings (has full paths in format: /path/to/file:namespace_info)
         [[ -s "$TEMP_DIR/namespace_warnings.txt" ]] && cut -d: -f1 "$TEMP_DIR/namespace_warnings.txt" || true
+        # Trufflehog rows graded LOW (see _trufflehog_by_severity)
+        _trufflehog_by_severity LOW || true
     } | sort -u >> "$log_file"
 
     print_status "$GREEN" "Log saved to: $log_file"
@@ -5155,6 +5159,29 @@ _jf_path() {
 
 # _jf_pathmsg SEVERITY FILE  -> each line is "path:reason"; split on FIRST colon
 # (mirrors `cut -d: -f1` for the path, but keeps the reason as the message).
+# Function: _trufflehog_by_severity
+# Purpose: trufflehog_activity.txt stores entries as "path:SEVERITY:message" and mixes
+#          HIGH, MEDIUM and LOW in one file. Emit only the rows of one severity.
+# Args: $1 = "HIGH" | "MEDIUM" | "LOW"; $2 = "paths" (default) or "pathmsg"
+# Note: The --save-log and --json writers used to dump the WHOLE file as HIGH, so a
+#       file that merely mentions trufflehog — a MEDIUM finding — was recorded as HIGH.
+#       In --bulk that produced rows like "🟡 MEDIUM RISK (H:4 M:0 L:0)": the label
+#       comes from the child exit code (correctly MEDIUM) while the counts come from
+#       the log (wrongly HIGH). The crypto_patterns writer already filtered this way.
+_trufflehog_by_severity() {
+    local want="$1" mode="${2:-paths}"
+    [[ -s "$TEMP_DIR/trufflehog_activity.txt" ]] || return 0
+    awk -F: -v want="$want" -v mode="$mode" '
+        $2 == want {
+            if (mode == "paths") { print $1; next }
+            rest = $0
+            sub(/^[^:]*:[^:]*:/, "", rest)
+            print $1 ":" rest
+        }
+    ' "$TEMP_DIR/trufflehog_activity.txt"
+    return 0
+}
+
 _jf_pathmsg() {
     local sev="$1" f="$2" line path msg
     [[ -s "$f" ]] || return 0
@@ -5228,7 +5255,9 @@ write_json_file() {
         _jf_path    HIGH "Shai-Hulud runner reference"                     "$TEMP_DIR/github_sha1hulud_runners.txt"
         _jf_path    HIGH "Known malicious repository description marker"    "$TEMP_DIR/malicious_repo_descriptions.txt"
         _jf_pathmsg HIGH "$TEMP_DIR/compromised_found.txt"
-        _jf_pathmsg HIGH "$TEMP_DIR/trufflehog_activity.txt"
+        _trufflehog_by_severity HIGH   pathmsg | _jf_pathmsg_stdin HIGH
+        _trufflehog_by_severity MEDIUM pathmsg | _jf_pathmsg_stdin MEDIUM
+        _trufflehog_by_severity LOW    pathmsg | _jf_pathmsg_stdin LOW
         _jf_path    HIGH "Shai-Hulud marker repository"                    "$TEMP_DIR/shai_hulud_repos.txt"
         [[ -s "$TEMP_DIR/crypto_patterns.txt" ]] && \
             grep -E "(HIGH RISK|Known attacker wallet)" "$TEMP_DIR/crypto_patterns.txt" 2>/dev/null | _jf_pathmsg_stdin HIGH || true

--- a/test-cases/secret-scanner-mention/README.md
+++ b/test-cases/secret-scanner-mention/README.md
@@ -1,0 +1,17 @@
+# secret-scanner-mention
+
+A bare reference to the trufflehog tool name is a MEDIUM finding
+(`Contains trufflehog references in source code`) — common in security tooling
+and CI glue, and not on its own evidence of anything.
+
+This fixture pins *severity attribution*. `trufflehog_activity.txt` stores
+`path:SEVERITY:message` and mixes HIGH, MEDIUM and LOW; the `--save-log` and
+`--json` writers used to dump the whole file into the HIGH bucket, so this
+MEDIUM finding was recorded as HIGH. Under `--bulk` that produced rows reading
+`🟡 MEDIUM RISK (H:4 M:0 L:0)` — label from the exit code, counts from the log.
+
+The directory is deliberately NOT named after the tool: a path containing
+"trufflehog" matches the binary-name check and would be flagged HIGH,
+defeating the point.
+
+Inert: a string constant naming the tool. Nothing is downloaded or executed.

--- a/test-cases/secret-scanner-mention/package.json
+++ b/test-cases/secret-scanner-mention/package.json
@@ -1,0 +1,1 @@
+{"name":"secret-scanner-mention","version":"1.0.0"}

--- a/test-cases/secret-scanner-mention/scan.js
+++ b/test-cases/secret-scanner-mention/scan.js
@@ -1,0 +1,3 @@
+// Inert fixture: a bare mention of the tool name, which grades MEDIUM.
+const SECRET_SCANNER = "trufflehog";
+export default SECRET_SCANNER;


### PR DESCRIPTION
## The symptom

A `--bulk` row that contradicts itself:

```
🟡 MEDIUM RISK  (H:4 M:0 L:0)
```

## The cause

`trufflehog_activity.txt` stores entries as `path:SEVERITY:message` and mixes HIGH, MEDIUM and LOW in one file:

```
foo.js:HIGH:Trufflehog binary found
bar.js:MEDIUM:Contains trufflehog references in source code
baz.js:LOW:Potentially suspicious environment variable access
```

But the `--save-log` writer dumped the whole file into the HIGH bucket, discarding the severity field:

```bash
[[ -s "$TEMP_DIR/trufflehog_activity.txt" ]] && cut -d: -f1 "$TEMP_DIR/trufflehog_activity.txt" || true
```

A file that merely *mentions* trufflehog is MEDIUM — common in security tooling and CI glue — so it was recorded as HIGH.

In `--bulk` the row label comes from the child's **exit code** (correctly MEDIUM, since only `medium_risk` was incremented) while the H/M/L counts are parsed from the **saved log** (wrongly HIGH). Hence the contradiction.

Minimal repro — one file whose only content is the tool name:

```
$ ./shai-hulud-detector.sh --save-log log.txt proj/    # exit 2 (MEDIUM)
$ cat log.txt
# HIGH
/…/proj/scan.js        ← should be under MEDIUM
# MEDIUM
# LOW
```

**`--json` was affected identically** (`_jf_pathmsg HIGH "$TEMP_DIR/trufflehog_activity.txt"`), marking every trufflehog finding HIGH. That one matters more, since it's the machine-readable output downstream tooling is meant to build on.

This invites mis-triage in both directions: trust the label and you deprioritise apparent HIGH findings; trust the counts and you chase MEDIUM ones.

## The fix

Each severity is emitted into its own section, matching what the neighbouring `crypto_patterns.txt` writer already did:

```bash
grep -E "(HIGH RISK|Known attacker wallet)" "$TEMP_DIR/crypto_patterns.txt" | cut -d: -f1
```

The `--json` message also no longer carries a redundant `HIGH:` / `MEDIUM:` prefix.

## Tests

`test-cases/secret-scanner-mention/` — the only marker is a bare reference to the tool name.

The directory is deliberately **not** named after the tool: a path containing `trufflehog` matches the binary-name check and gets flagged HIGH, which would defeat the fixture's purpose. I hit exactly that while writing it.

Two assertions pin the severity in `--save-log` and in `--json`; both fail on unpatched code. The `--json` one skips when `jq` is absent, matching the existing convention.

Suite: 238 → 241 checks, `./run-tests.sh` passes 241/241.

## Notes

- Version bumped to 3.20.0. Independent of #158–#164; whichever lands last needs a trivial CHANGELOG/version rebase.
- Only the *reporting* of these findings changes — detection, grading and exit codes are untouched. Exit codes were already correct; it was the log and JSON that disagreed with them.

## Sources

Internally found while rehearsing a company-wide rollout — the contradictory `--bulk` row is what gave it away.