### PR TITLE
Scope the destructive home-directory regex to real home wipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Shai-Hulud NPM Supply Chain Attack Detector will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.21.0] - 2026-08-06
+## [3.14.4] - 2026-08-06
 
 ### Fixed
 - **`check_destructive_patterns` flagged ordinary scoped removals below `/home/` as destructive payloads.** The `/home/` alternative of `basic_destructive_regex` had no tail constraint, so it matched **any** path under `/home/`. A legitimate deployment line such as `rm -rf /home/myapp/.deployer` — the case that surfaced this — was reported as `🚨 CRITICAL: Destructive payload patterns detected`, which escalates the entire scan to HIGH RISK and exit code 1. The same applied to `rm -rf /home/user/project/node_modules`, `rm -rf /home/ci/workspace/build` and `find /home/app/logs -mtime +30 -delete`. `$HOME` was over-matched the same way (`rm -rf $HOME/.cache/foo`, `rm -rf $HOME/project/build`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the Shai-Hulud NPM Supply Chain Attack Detector will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.21.0] - 2026-08-06
+
+### Fixed
+- **`check_destructive_patterns` flagged ordinary scoped removals below `/home/` as destructive payloads.** The `/home/` alternative of `basic_destructive_regex` had no tail constraint, so it matched **any** path under `/home/`. A legitimate deployment line such as `rm -rf /home/myapp/.deployer` — the case that surfaced this — was reported as `🚨 CRITICAL: Destructive payload patterns detected`, which escalates the entire scan to HIGH RISK and exit code 1. The same applied to `rm -rf /home/user/project/node_modules`, `rm -rf /home/ci/workspace/build` and `find /home/app/logs -mtime +30 -delete`. `$HOME` was over-matched the same way (`rm -rf $HOME/.cache/foo`, `rm -rf $HOME/project/build`).
+  - **Impact:** false CRITICAL on any repository that documents or scripts a scoped cleanup under a home directory — deployment scripts, CI cleanup steps, Dockerfiles, runbooks. CRITICAL findings are the one class of result the tool tells users to act on immediately ("Quarantine these files"), so a false positive here is expensive.
+- **The same regex silently MISSED the most common real home-directory wipes.** The `~` alternative was `~[^a-zA-Z0-9_/]`: it excluded `/`, could not match at end-of-line, allowed no leading quote and had no brace-expansion form. Measured against the old pattern, **7 of 21** genuine wipe spellings were not detected: `rm -rf ~`, `rm -rf ~/`, `rm -rf ~/*`, `rm -rf "$HOME"`, `rm -rf ${HOME}`, `rm -rf ~bob`, `rm -rf "/home/bob"`.
+  - `rm -rf ~/*` is literally `PATTERN_2` of `test-cases/destructive-patterns/cleanup.sh`. That fixture only ever passed because of its *other* lines, so the gap was invisible to the suite.
+  - Combined, the old pattern got **13 of 30** measured cases wrong (7 false negatives, 6 false positives).
+
+### Changed
+- **`basic_destructive_regex` now bounds the path tail.** After `$HOME` / `${HOME}` / `~` / `~user` / `/home/` the pattern accepts **at most one** path component, optionally followed by `/` or `/*`, and then requires a non-path character or end-of-line (`([^a-zA-Z0-9._$~{}*/-]|$)`). Two levels deep is a scoped subdirectory removal, not a home wipe. An optional leading `["']` and a `\$\{?HOME\}?` alternative were added, and the bare-`~` form now accepts `~[a-zA-Z0-9._-]*`. The same construction is applied to the `find … -exec rm` and `find … -delete` alternatives; the `del /s /q` and `Remove-Item -Recurse` alternatives gained the optional quote only.
+  - **Newly detected:** `rm -rf ~`, `rm -rf ~/`, `rm -rf ~/*`, `rm -rf "$HOME"`, `rm -rf ${HOME}`, `rm -rf ~bob`, `rm -rf "/home/bob"`.
+  - **Newly excluded:** `rm -rf /home/myapp/.deployer`, `rm -rf /home/user/project/node_modules`, `rm -rf /home/ci/workspace/build`, `rm -rf $HOME/.cache/foo`, `rm -rf $HOME/project/build`, `find /home/app/logs -mtime +30 -delete`.
+  - **Unchanged verdicts:** all 21 true-positive spellings still fire (`rm -rf $HOME`, `$HOME/`, `$HOME/*`, `/home/`, `/home/*`, `/home/bob`, `/home/bob/`, `/home/bob/*`, `/home/$USER`, `find $HOME … -delete`, `find ~ -exec rm`, `del /s /q %USERPROFILE%`, `Remove-Item -Recurse $HOME`, …), and the existing `test-cases/destructive-patterns` and `test-cases/minified-false-positives` fixtures keep their exact pre-change findings and risk counts.
+  - Verified case-by-case (30 cases × 3 backends) under `grep -E`, `git grep -E --no-index` and `rg`, all with `-i`, matching production's `fast_grep_files_i`; results are identical across all three.
+
+### Added
+- **`test-cases/destructive-home-subdir-fp/`** — inert fixture whose `deploy.sh` holds the nine scoped removals above as string variables. Expected verdict: clean, exit 0. Fails on the unpatched code.
+- **`test-cases/destructive-home-wipe/`** — inert fixture whose `wiper.sh` holds the seven previously-missed whole-home wipes. Expected verdict: CRITICAL destructive payload, exit 1. Fails on the unpatched code.
+- **Two dedicated assertions in `run-tests.sh`** (before the paranoid-mode confusable block) asserting that `rm -rf /home/myapp/.deployer` is *not* flagged and `rm -rf "$HOME"` *is*. Both fixtures are in-tree rather than in `$TMPDIR` so the assertions hold on the git-grep backend too, which can only address paths under the scan root. Suite: 245 → **249** checks.
+
+### Changed (metadata)
+- **`shai-hulud-detector.sh`**: `SCRIPT_VERSION` → 3.21.0.
+- **`README.md`**: tests badge and suite count 245 → 249.
+
 ## [3.14.3] - 2026-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Shell](https://img.shields.io/badge/shell-Bash%205.0%2B-blue)](#requirements)
 [![Status](https://img.shields.io/badge/status-Active-success)](../../)
-[![Tests](https://img.shields.io/badge/tests-245%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-249%20passing-brightgreen)](#testing)
 [![Packages](https://img.shields.io/badge/compromised%20packages-3%2C460%2B-red)](compromised-packages.txt)
 [![Type](https://img.shields.io/badge/type-Security%20Tool-red)](#what-it-catches)
 [![Contributions](https://img.shields.io/badge/contributions-Welcome-orange)](#contributing)
@@ -253,7 +253,7 @@ To add new packages from a fresh advisory: append entries in that format, run `.
 ## Testing
 
 ```bash
-./run-tests.sh                          # full suite, 245 checks
+./run-tests.sh                          # full suite, 249 checks
 ./shai-hulud-detector.sh test-cases/<fixture-name>   # run one fixture manually
 ```
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -43,6 +43,8 @@ declare -A EXPECTED=(
     ["comprehensive-test"]="0|no|no|no"        # Clean
     ["debug-js"]="0|no|no|no"                  # Clean
     ["destructive-patterns"]="1|no|yes|no"     # MEDIUM: secret scanning (not HIGH)
+    ["destructive-home-subdir-fp"]="0|no|no|no" # Clean: scoped removals BELOW a home dir (rm -rf /home/myapp/.deployer, $HOME/.cache/foo, ~/tmp/build) must not fire the destructive-payload check
+    ["destructive-home-wipe"]="1|no|no|no"     # CRITICAL: whole-home wipes the old regex missed (rm -rf "$HOME", rm -rf ${HOME}, rm -rf ~, ~/, ~bob, "/home/bob")
     ["discussion-workflows"]="1|yes|no|no"     # HIGH: malicious workflows
     ["edge-case-project"]="0|no|no|no"         # Clean (no detections)
     ["false-positive-project"]="2|no|yes|no"   # MEDIUM: potential false positives
@@ -766,6 +768,42 @@ else
     rm -rf "$BACKEND_TMP/fakehome"
 fi
 rm -rf "$BACKEND_TMP"
+
+# ============================================================
+#  Destructive-payload home-directory scoping regression
+# ============================================================
+# Lock in the basic_destructive_regex fix in check_destructive_patterns.
+#
+# Over-match: the old "/home/" alternative matched ANY path below /home/, so a
+# legitimate deployment line "rm -rf /home/myapp/.deployer" was reported as
+# "CRITICAL: Destructive payload patterns detected".
+#
+# Under-match: the old "~[^a-zA-Z0-9_/]" alternative excluded "/", could not
+# match at end-of-line and allowed neither a leading quote nor ${HOME}, so the
+# real wipes 'rm -rf "$HOME"', "rm -rf ${HOME}", "rm -rf ~", "rm -rf ~/" and
+# "rm -rf ~/*" were all MISSED.
+#
+# The fixtures are in-tree (NOT $TMPDIR) so the assertions also hold on the
+# git-grep backend, which can only address paths under the scan root.
+DESTR_FP_OUT=$("$BASH_CMD" "$DETECTOR" "$SCRIPT_DIR/test-cases/destructive-home-subdir-fp" 2>&1)
+((total++))
+if grep -qF "Destructive payload patterns detected" <<< "$DESTR_FP_OUT"; then
+    echo -e "${RED}FAIL${NC}: destructive-home-subdir-fp wrongly flagged a scoped removal (rm -rf /home/myapp/.deployer) as destructive"
+    ((failed++))
+else
+    echo -e "${GREEN}PASS${NC}: destructive-home-subdir-fp does NOT flag 'rm -rf /home/myapp/.deployer' as destructive"
+    ((passed++))
+fi
+
+DESTR_WIPE_OUT=$("$BASH_CMD" "$DETECTOR" "$SCRIPT_DIR/test-cases/destructive-home-wipe" 2>&1)
+((total++))
+if grep -qF "Destructive payload patterns detected" <<< "$DESTR_WIPE_OUT"; then
+    echo -e "${GREEN}PASS${NC}: destructive-home-wipe flags the quoted home wipe (rm -rf \"\$HOME\") as destructive"
+    ((passed++))
+else
+    echo -e "${RED}FAIL${NC}: destructive-home-wipe did NOT flag 'rm -rf \"\$HOME\"' (the home-wipe regex is broken)"
+    ((failed++))
+fi
 
 # ============================================================
 #  Paranoid-mode confusable-substring regression

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPROMISED_PACKAGES_FILE="$SCRIPT_DIR/compromised-packages.txt"
 
 # Tool version (surfaced in --json output for downstream consumers)
-SCRIPT_VERSION="3.14.3"
+SCRIPT_VERSION="3.21.0"
 
 # Global temp directory for file-based storage
 TEMP_DIR=""
@@ -3677,7 +3677,19 @@ check_destructive_patterns() {
     # Basic destructive patterns - ONLY flag when targeting user directories ($HOME, ~, /home/)
     # Standalone rimraf/unlinkSync/rmSync removed to reduce false positives (GitHub issue #74)
     # Standalone glob patterns ($HOME/*, ~/*) removed - they match comments/docs (GitHub issue #105)
-    local basic_destructive_regex="rm -rf[[:space:]]+(\\\$HOME|~[^a-zA-Z0-9_/]|/home/)|del /s /q[[:space:]]+(%USERPROFILE%|\\\$HOME)|Remove-Item -Recurse[[:space:]]+(\\\$HOME|~[^a-zA-Z0-9_/])|find[[:space:]]+(\\\$HOME|~[^a-zA-Z0-9_/]|/home/).*-exec rm|find[[:space:]]+(\\\$HOME|~[^a-zA-Z0-9_/]|/home/).*-delete"
+    #
+    # Home-directory targets are matched with a bounded tail: after $HOME / ${HOME} / ~ / /home/
+    # we allow AT MOST ONE path component, optionally followed by "/" or "/*", and then require a
+    # non-path character or end-of-line. Rationale:
+    #   (a) The old "/home/" alternative matched ANY path below /home/, so a legitimate deployment
+    #       doc line such as "rm -rf /home/myapp/.deployer" was reported as a destructive payload.
+    #       Two levels deep is a subdirectory removal, not a home-directory wipe, so the tail
+    #       terminator ([^a-zA-Z0-9._$~{}*/-]|$) now excludes it.
+    #   (b) The old "~[^a-zA-Z0-9_/]" alternative excluded "/" and could not match at end-of-line,
+    #       and there was no allowance for quotes or brace expansion. As a result the real wipes
+    #       "rm -rf ~", "rm -rf ~/", "rm -rf ~/*", 'rm -rf "$HOME"' and "rm -rf ${HOME}" were all
+    #       MISSED. The optional leading ["'] plus \$\{?HOME\}? and ~[a-zA-Z0-9._-]* now cover them.
+    local basic_destructive_regex="rm -rf[[:space:]]+[\"']?((\\\$\\{?HOME\\}?|~[a-zA-Z0-9._-]*)(/[*]?)?([^a-zA-Z0-9._\$~{}*/-]|\$)|/home/([a-zA-Z0-9._\$~{}*-]+(/[*]?)?)?([^a-zA-Z0-9._\$~{}*/-]|\$))|del /s /q[[:space:]]+[\"']?(%USERPROFILE%|\\\$HOME)|Remove-Item -Recurse[[:space:]]+[\"']?(\\\$HOME|~[^a-zA-Z0-9_/])|find[[:space:]]+[\"']?((\\\$\\{?HOME\\}?|~[a-zA-Z0-9._-]*)(/[*]?)?([^a-zA-Z0-9._\$~{}*/-]|\$)|/home/([a-zA-Z0-9._\$~{}*-]+(/[*]?)?)?([^a-zA-Z0-9._\$~{}*/-]|\$)).*-exec rm|find[[:space:]]+[\"']?((\\\$\\{?HOME\\}?|~[a-zA-Z0-9._-]*)(/[*]?)?([^a-zA-Z0-9._\$~{}*/-]|\$)|/home/([a-zA-Z0-9._\$~{}*-]+(/[*]?)?)?([^a-zA-Z0-9._\$~{}*/-]|\$)).*-delete"
 
     # Shai-Hulud 2.0 wiper patterns - SPECIFIC signatures from actual malware (Koi Security disclosure)
     # These tight patterns eliminate false positives on TypeScript/minified JS (GitHub issue #105)

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPROMISED_PACKAGES_FILE="$SCRIPT_DIR/compromised-packages.txt"
 
 # Tool version (surfaced in --json output for downstream consumers)
-SCRIPT_VERSION="3.21.0"
+SCRIPT_VERSION="3.14.4"
 
 # Global temp directory for file-based storage
 TEMP_DIR=""

--- a/test-cases/destructive-home-subdir-fp/README.md
+++ b/test-cases/destructive-home-subdir-fp/README.md
@@ -1,0 +1,53 @@
+# Destructive Home Subdirectory False-Positive Test Case
+
+This test case locks in the fix for the `/home/` over-match in
+`check_destructive_patterns` (`basic_destructive_regex`).
+
+## Problem Description
+
+The `/home/` alternative of the destructive-payload regex used to match **any**
+path below `/home/`. A perfectly legitimate deployment line such as
+
+```
+rm -rf /home/myapp/.deployer
+```
+
+was therefore reported as `CRITICAL: Destructive payload patterns detected`,
+which escalates the whole scan to HIGH RISK.
+
+The regex now allows at most **one** path component after `$HOME` / `${HOME}` /
+`~` / `/home/`, optionally followed by `/` or `/*`, and then requires a
+non-path character or end-of-line. Two levels deep is a scoped subdirectory
+removal, not a home-directory wipe.
+
+## Defanging Approach
+
+`deploy.sh` stores every command as an inert string variable, following the
+same convention as `test-cases/destructive-patterns`. Running the file does
+nothing.
+
+## Test Files
+
+### deploy.sh (Should NOT trigger alerts)
+
+Scoped removals that must all stay below the detection threshold:
+
+- `rm -rf /home/myapp/.deployer` (the regressed line)
+- `rm -rf /home/user/project/node_modules`
+- `rm -rf /home/ci/workspace/build`
+- `rm -rf $HOME/.cache/foo`, `rm -rf $HOME/project/build`
+- `rm -rf ~/tmp/build`, `rm -rf ~/.npm/_cacache`
+- `rm -rf ./dist`
+- `find /home/app/logs -mtime +30 -delete`
+
+## Expected Results
+
+When running `./shai-hulud-detector.sh test-cases/destructive-home-subdir-fp/`:
+
+**Should NOT detect:**
+
+- No destructive payload patterns
+- Clean result, exit code 0
+
+The complementary positive case lives in
+`test-cases/destructive-home-wipe/`.

--- a/test-cases/destructive-home-subdir-fp/deploy.sh
+++ b/test-cases/destructive-home-subdir-fp/deploy.sh
@@ -1,0 +1,26 @@
+# INERT TEST FIXTURE - legitimate scoped cleanup below a home directory.
+# Nothing here executes: every command is stored as an inert string variable,
+# exactly like the neighbouring test-cases/destructive-patterns fixture.
+#
+# All of these target a SUBDIRECTORY (two or more levels below $HOME / ~ / /home/).
+# That is an ordinary scoped removal, not a home-directory wipe, and it must NOT
+# be reported as "CRITICAL: Destructive payload patterns detected".
+
+# The line that regressed: a deployment doc / script removing one app's state dir.
+SCOPED_1='rm -rf /home/myapp/.deployer'
+
+# Further scoped removals that used to over-match the old "/home/" alternative.
+SCOPED_2='rm -rf /home/user/project/node_modules'
+SCOPED_3='rm -rf /home/ci/workspace/build'
+
+# Scoped removals below $HOME and ~.
+SCOPED_4='rm -rf $HOME/.cache/foo'
+SCOPED_5='rm -rf $HOME/project/build'
+SCOPED_6='rm -rf ~/tmp/build'
+SCOPED_7='rm -rf ~/.npm/_cacache'
+
+# Relative removal - never home-directory related.
+SCOPED_8='rm -rf ./dist'
+
+# find(1) restricted to an application log directory, not to the home directory.
+SCOPED_9='find /home/app/logs -mtime +30 -delete'

--- a/test-cases/destructive-home-subdir-fp/package.json
+++ b/test-cases/destructive-home-subdir-fp/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "destructive-home-subdir-fp",
+  "version": "1.0.0",
+  "description": "Fixture: scoped removals below a home directory must not be flagged as destructive",
+  "private": true,
+  "license": "MIT"
+}

--- a/test-cases/destructive-home-wipe/README.md
+++ b/test-cases/destructive-home-wipe/README.md
@@ -1,0 +1,58 @@
+# Destructive Home Wipe Test Case
+
+This test case locks in the false-**negative** half of the
+`basic_destructive_regex` fix in `check_destructive_patterns`.
+
+## Problem Description
+
+The old regex only accepted a bare `$HOME` or `~` followed by a character that
+was neither alphanumeric nor `/`. It had no allowance for a leading quote, no
+brace-expansion alternative, and could not match at end-of-line. As a result
+these real home-directory wipes were silently **missed**:
+
+```
+rm -rf ~
+rm -rf ~/
+rm -rf ~/*
+rm -rf "$HOME"
+rm -rf ${HOME}
+rm -rf ~bob
+rm -rf "/home/bob"
+```
+
+Note that `rm -rf ~/*` is literally `PATTERN_2` of
+`test-cases/destructive-patterns/cleanup.sh`; that fixture only passed because
+of its *other* lines.
+
+## Defanging Approach
+
+`wiper.sh` stores every command as an inert string variable, following the same
+convention as `test-cases/destructive-patterns`. Running the file does nothing.
+
+## Test Files
+
+### wiper.sh (Should trigger alerts)
+
+- `rm -rf "$HOME"` (quoted)
+- `rm -rf ${HOME}` (brace-expanded)
+- `rm -rf ~` and `rm -rf ~/` (bare tilde)
+- `rm -rf ~bob` (other user's home)
+- `rm -rf "/home/bob"` (quoted absolute home)
+- `rm -rf /home/` (whole /home tree)
+
+## Expected Results
+
+When running `./shai-hulud-detector.sh test-cases/destructive-home-wipe/`:
+
+**Should detect (CRITICAL level):**
+
+- Basic destructive pattern detected in `wiper.sh`
+- HIGH RISK verdict, exit code 1
+
+The complementary negative case lives in
+`test-cases/destructive-home-subdir-fp/`.
+
+## Warning Level: CRITICAL
+
+These patterns indicate potential for permanent data loss and require immediate
+quarantine.

--- a/test-cases/destructive-home-wipe/package.json
+++ b/test-cases/destructive-home-wipe/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "destructive-home-wipe",
+  "version": "1.0.0",
+  "description": "Fixture: quoted/braced home-directory wipes must be flagged as destructive",
+  "private": true,
+  "license": "MIT"
+}

--- a/test-cases/destructive-home-wipe/wiper.sh
+++ b/test-cases/destructive-home-wipe/wiper.sh
@@ -1,0 +1,28 @@
+# DEFANGED TEST FIXTURE - home-directory wipe signatures for detection testing.
+# These patterns are stored as inert string data, not executable commands, in
+# the same style as test-cases/destructive-patterns. Running this file does
+# nothing harmful.
+#
+# Every line below wipes the whole home directory and MUST be reported as
+# "CRITICAL: Destructive payload patterns detected". The quoted, braced and
+# bare-tilde spellings were all MISSED by the previous regex.
+
+# Quoted $HOME - previously missed (no allowance for a leading quote).
+WIPE_1='rm -rf "$HOME"'
+
+# Brace-expanded ${HOME} - previously missed.
+WIPE_2='rm -rf ${HOME}'
+
+# Bare tilde and tilde with trailing slash - previously missed because the old
+# ~[^a-zA-Z0-9_/] alternative excluded "/" and could not match at end-of-line.
+WIPE_3='rm -rf ~'
+WIPE_4='rm -rf ~/'
+
+# Other-user home directory via tilde expansion - previously missed.
+WIPE_5='rm -rf ~bob'
+
+# Quoted absolute home path - previously missed.
+WIPE_6='rm -rf "/home/bob"'
+
+# Whole /home tree.
+WIPE_7='rm -rf /home/'


### PR DESCRIPTION
## Two problems in one regex

`basic_destructive_regex` in `check_destructive_patterns` handles `$HOME` / `~` / `/home/`. Both halves are wrong, in opposite directions.

**False positives.** `/home/` matches any path beneath it, so ordinary deployment documentation trips a CRITICAL finding:

```
🚨 CRITICAL: Destructive payload patterns detected:
   - doc/static/dokus/search-index.json
     Pattern: Basic destructive pattern detected
```

The matched content was a documented cleanup step, indexed by a docs generator:

```
rm -rf /home/myapp/.deployer
```

Removing one subdirectory that happens to live under `/home/` is not a home wipe.

**False negatives, which matter more.** `~[^a-zA-Z0-9_/]` excludes `/`, so the most idiomatic wipes are missed entirely:

| pattern | current |
|---|---|
| `rm -rf ~` | **missed** |
| `rm -rf ~/` | **missed** |
| `rm -rf ~/*` | **missed** |
| `rm -rf "$HOME"` | **missed** |
| `rm -rf ${HOME}` | **missed** |
| `rm -rf $HOME` | matched |

The quoted form is what a careful script author actually writes. And `rm -rf ~/*` is literally `PATTERN_2` in this repo's own `test-cases/destructive-patterns/cleanup.sh` — that fixture passes only because of its *other* lines.

## The fix

After `$HOME` / `~` / `/home/`, allow at most one path component optionally followed by `/` or `/*`, then require a non-path terminator or end of line. Two levels deep is a subdirectory removal, not a home wipe. The same tail logic is applied to the `$HOME`/`~` branches, which also picks up `${HOME}`, `~user` and quoted forms.

## Verification

30 cases across `grep -E`, `git grep -E --no-index` and `rg` (all `-i`, as `fast_grep_files_i` uses). **All three backends agree on every case; 0 disagreements.**

- **21/21 must-match**, including the 7 the current rule misses
- **9/9 must-not-match**, including the reported false positive

Against the same 30 cases the current regex gets **13 wrong** — 7 false negatives, 6 false positives.

Newly excluded, for the record: `rm -rf /home/$USER/.ssh` (targeted credential deletion, not the wiper behaviour) and `find /home/app/logs -mtime +30 -delete`. Neither is Shai-Hulud wiper behaviour.

Left alone as out of scope: `rm -rf --no-preserve-root /home/` (flag between command and path) and `rm -rf /`.

## Tests

Two in-tree fixtures with READMEs, inert string constants only:

| fixture | expectation |
|---|---|
| `destructive-home-subdir-fp/` | `rm -rf /home/myapp/.deployer` — **must stay clean** |
| `destructive-home-wipe/` | `rm -rf "$HOME"` — **must be flagged** |

Plus two dedicated assertions. Existing fixtures keep identical verdicts, checked side by side against the unpatched script: `destructive-patterns` High 4 / Med 2, `minified-false-positives` High 2 / Med 2, before and after.

Suite: 245 → 249 checks, `./run-tests.sh` passes 249/249.

## Note

Thanks for merging #158. This branches from current `main` (3.14.3) and bumps to 3.14.4.

## Sources

Internally found while rolling the detector out — the false positive fired on our own deployment tool's documentation, and testing the fix surfaced the false negatives.