### PR TITLE
Add @nebula.js/cli-serve@7.1.2 to the keyv/cacheable wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the Shai-Hulud NPM Supply Chain Attack Detector will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.4] - 2026-08-06
+
+### Added
+- **`@nebula.js/cli-serve:7.1.2` — one keyv/cacheable-wave version the list was missing.** The August 4 section and the August 5 re-sync were both built from `wiz-sec-public/wiz-research-iocs`, `reports/keyv-packages.csv`, which does not list this package at all, so the `@nebula.js` block covered 21 of the scope's 22 trojanized packages.
+  - Confirmed independently of Wiz by OSV `MAL-2026-11568` / `GHSA-p6mm-86xq-m5x4`, whose affected set is exactly `["7.1.2"]`, and by the npm registry, which still records `time["7.1.2"] = 2026-08-04T10:46:39.018Z` while no longer serving the version (`dist-tags.latest` is back to `7.1.1`). That timestamp falls inside the same 10:46:37-10:46:39 UTC burst that published `@nebula.js/cli-build`, `cli-sense`, `cli` and `stardust` at `7.1.2`.
+  - Recorded as a dated addendum block at the end of `compromised-packages.txt`, following the 2026-08-05 re-sync convention; the original `# @nebula.js (Qlik)` block is left as written.
+  - Before this change, a project pinning `@nebula.js/cli-serve@7.1.2` scanned clean — `@nebula.js` has no namespace-level fallback, so an exact version match is the only path to detection.
+
+### Changed
+- **`compromised-packages.txt`**: 5,699 → **5,700** entries; keyv section header updated to 444 packages / 2,236 versions.
+- **`shai-hulud-detector.sh`**: `SCRIPT_VERSION` 3.14.3 → 3.14.4.
+- **`run-tests.sh` / `test-cases/keyv-shai-hulud-attack`**: the fixture now pins `@nebula.js/cli-serve@7.1.2` and the suite asserts it is flagged. Suite: 245 → 246 checks.
+
+### Notes
+- Detection-only change; no detector logic was touched. A missing entry can only cause a missed detection of an already-public bad version, never a false positive.
+
 ## [3.14.3] - 2026-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Shell](https://img.shields.io/badge/shell-Bash%205.0%2B-blue)](#requirements)
 [![Status](https://img.shields.io/badge/status-Active-success)](../../)
-[![Tests](https://img.shields.io/badge/tests-245%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-246%20passing-brightgreen)](#testing)
 [![Packages](https://img.shields.io/badge/compromised%20packages-3%2C460%2B-red)](compromised-packages.txt)
 [![Type](https://img.shields.io/badge/type-Security%20Tool-red)](#what-it-catches)
 [![Contributions](https://img.shields.io/badge/contributions-Welcome-orange)](#contributing)
@@ -11,7 +11,7 @@
 
 <img src="shai_hulu_detector.jpg" alt="sshd" width="80%" />
 
-A Bash script that scans a project — or many projects at once — for known traces of the September 2025 → August 2026 npm, PyPI, Composer, Crates, Go, Hex, and RubyGems supply-chain attacks. Cross-checks 5,699 confirmed bad package versions and a library of content-pattern IoCs (file hashes, C2 domains, dead-man's-switch artifacts, wipe-threat strings, AI-assistant config droppers, etc.).
+A Bash script that scans a project — or many projects at once — for known traces of the September 2025 → August 2026 npm, PyPI, Composer, Crates, Go, Hex, and RubyGems supply-chain attacks. Cross-checks 5,700 confirmed bad package versions and a library of content-pattern IoCs (file hashes, C2 domains, dead-man's-switch artifacts, wipe-threat strings, AI-assistant config droppers, etc.).
 
 ## Quick Start
 
@@ -36,7 +36,7 @@ chmod +x shai-hulud-detector.sh
 
 The detector looks for two kinds of evidence on disk:
 
-1. **Compromised package versions** — every `package.json`, lockfile, `pyproject.toml`, `requirements.txt`, `Pipfile`, `poetry.lock`, `uv.lock`, etc. is parsed and the resolved versions are checked against the 5,699-entry list in [`compromised-packages.txt`](compromised-packages.txt). Transitive deps inside `node_modules/` are checked too, not skipped.
+1. **Compromised package versions** — every `package.json`, lockfile, `pyproject.toml`, `requirements.txt`, `Pipfile`, `poetry.lock`, `uv.lock`, etc. is parsed and the resolved versions are checked against the 5,700-entry list in [`compromised-packages.txt`](compromised-packages.txt). Transitive deps inside `node_modules/` are checked too, not skipped.
 2. **Content-pattern IoCs** — known-malicious file hashes, payload filenames, C2 domains, dead-man's-switch artifacts, marker repo names, malicious workflow files, forged orphan-commit references, suspicious lifecycle hooks, and threat-actor publisher fingerprints. These don't depend on the package list and fire even if the bad package has been uninstalled but the dropper traces remain.
 
 | Wave | Date | Scope |
@@ -253,7 +253,7 @@ To add new packages from a fresh advisory: append entries in that format, run `.
 ## Testing
 
 ```bash
-./run-tests.sh                          # full suite, 245 checks
+./run-tests.sh                          # full suite, 246 checks
 ./shai-hulud-detector.sh test-cases/<fixture-name>   # run one fixture manually
 ```
 

--- a/compromised-packages.txt
+++ b/compromised-packages.txt
@@ -1,6 +1,6 @@
 # Shai-Hulud Supply Chain Attack - Compromised Packages List
 #
-# This file contains 5,699 confirmed compromised package versions from
+# This file contains 5,700 confirmed compromised package versions from
 # multiple supply chain attacks between September 2025 and August 2026.
 # The campaigns were self-replicating, so new compromised packages may still be discovered.
 #
@@ -3968,7 +3968,7 @@ go:github.com/verana-labs/verana-blockchain:v0.10.1-dev.20
 
 # ========================================================================
 # AUGUST 4, 2026 - SHAI-HULUD "Here We Go Again" - keyv / cacheable wave
-# (443 npm packages, 2,235 versions; re-synced 2026-08-05, see block at end)
+# (444 npm packages, 2,236 versions; re-synced 2026-08-05 and 2026-08-06, see blocks at end)
 #
 # The largest npm supply-chain wave to date by install volume: >2 billion
 # monthly installs. Entry point was the compromised GitHub account of the
@@ -6307,3 +6307,21 @@ tslint-folder-schema:1.0.21
 umadev:1.0.74
 verdaccio-okta-oauth:38.1.16
 verdaccio-tarball-local-storage:38.1.16
+
+# ------------------------------------------------------------------------
+# ADDENDUM 2026-08-06 — one keyv-wave version the Wiz IoC CSV does not list.
+# @nebula.js/cli-serve@7.1.2 was trojanized in the same 2026-08-04
+# 10:46:37-10:46:39 UTC publish burst as the rest of the @nebula.js scope
+# (cli-build .237, cli-sense .262, cli .284, cli-serve 10:46:39.018,
+# stardust .344), but the package is absent from reports/keyv-packages.csv
+# entirely, so neither the 2026-08-04 section nor the 2026-08-05 re-sync
+# above picked it up. Confirmed by OSV MAL-2026-11568 /
+# GHSA-p6mm-86xq-m5x4, whose affected set is exactly ["7.1.2"], and by the
+# npm registry, which still records time["7.1.2"] =
+# 2026-08-04T10:46:39.018Z while no longer serving the version
+# (dist-tags.latest is back to 7.1.1). keyv-wave @nebula.js coverage is now
+# 22 packages / 22 versions.
+# ------------------------------------------------------------------------
+
+# @nebula.js — additional version (1 package, 1 version)
+@nebula.js/cli-serve:7.1.2

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -453,6 +453,7 @@ for keyv_check in \
     "flat-cache compromised version flagged|flat-cache@6.1.24" \
     "file-entry-cache compromised version flagged|file-entry-cache@11.1.6" \
     "scoped @or-sdk/auth compromised version flagged|@or-sdk/auth@0.38.2" \
+    "scoped @nebula.js/cli-serve compromised version flagged|@nebula.js/cli-serve@7.1.2" \
     "node setup.mjs preinstall hook flagged|Fake Bun preinstall patterns detected" \
     "npm-cache.com C2 fallback domain flagged|keyv/cacheable wave C2 fallback domain"
 do

--- a/shai-hulud-detector.sh
+++ b/shai-hulud-detector.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPROMISED_PACKAGES_FILE="$SCRIPT_DIR/compromised-packages.txt"
 
 # Tool version (surfaced in --json output for downstream consumers)
-SCRIPT_VERSION="3.14.3"
+SCRIPT_VERSION="3.14.4"
 
 # Global temp directory for file-based storage
 TEMP_DIR=""

--- a/test-cases/keyv-shai-hulud-attack/package.json
+++ b/test-cases/keyv-shai-hulud-attack/package.json
@@ -11,6 +11,7 @@
     "flat-cache": "6.1.24",
     "file-entry-cache": "11.1.6",
     "cacheable-request": "13.0.20",
-    "@or-sdk/auth": "0.38.2"
+    "@or-sdk/auth": "0.38.2",
+    "@nebula.js/cli-serve": "7.1.2"
   }
 }


### PR DESCRIPTION
Reconciled the two public per-version IoC lists for the 2026-08-04 wave — the Wiz CSV (443 packages / 2,235 versions) and the OX Security advisory table (444 / 2,058) — giving a union of 444 packages / 2,236 versions, and diffed it against compromised-packages.txt. Exactly one pair was missing: @nebula.js/cli-serve@7.1.2, the only pair contributed by OX alone.

Sources: OX Security advisory table; Wiz Research keyv-packages.csv (pinned at 22752e7c). Verified against the npm registry API. No tarball was downloaded or unpacked.

